### PR TITLE
pending.py: use the --main arg when checking out the base branch

### DIFF
--- a/pending.py
+++ b/pending.py
@@ -113,7 +113,7 @@ def main(args):
     namespace = args.namespace or settings.get('namespace') or 'kernelci'
     repo_name = '/'.join([namespace, args.project])
     repo = kernelci.GITHUB.get_repo(repo_name)
-    kernelci.checkout_repository(path, repo)
+    kernelci.checkout_repository(path, repo, branch=args.main)
 
     skip = get_skip_list(args, settings)
 


### PR DESCRIPTION
Rather than always checking out the 'main' branch, use the --main
command line argument to check out the base branch before merging PRs
and applying patches.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>