### PR TITLE
ansible: add argument with Ansible playbook git revision

### DIFF
--- a/ansible
+++ b/ansible
@@ -5,8 +5,9 @@ set -e
 repo="${1}"
 target="${2}"
 git_rev="${3:-staging.kernelci.org}"
-key="${4:-$PWD/keys/id_rsa_staging.kernelci.org}"
-opts="${5}"
+ansible_rev="${4:-main}"
+key="${5:-$PWD/keys/id_rsa_staging.kernelci.org}"
+opts="${6}"
 
 [ "$repo" = "kernelci-backend" ] || \
 [ "$repo" = "kernelci-frontend" ] || \
@@ -29,6 +30,7 @@ path="checkout/$repo-config"
 [ -e "$key" ] && key_arg="--private-key $key" || key_arg=""
 
 cd "$path"
+git checkout "$ansible_rev"
 git pull --ff-only
 ansible-playbook \
     site.yml \

--- a/kernelci.org
+++ b/kernelci.org
@@ -88,6 +88,7 @@ cmd_backend() {
         kernelci-backend \
         api.kernelci.org \
         $rev \
+        main \
         $PWD/keys/id_rsa_kernelci.org
 }
 
@@ -100,6 +101,7 @@ cmd_frontend() {
         kernelci-frontend \
         linux.kernelci.org \
         $rev \
+        main \
         $PWD/keys/id_rsa_kernelci.org
 }
 


### PR DESCRIPTION
Add an argument to the ansible helper script to specify the revision
of the playbook to use from the config git repository.  Update
kernelci.org accordingly to use the 'main' branch.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>