### PR TITLE
chromeos.kernelci.org: add script with config files

### DIFF
--- a/chromeos.kernelci.org
+++ b/chromeos.kernelci.org
@@ -1,0 +1,135 @@
+#!/bin/sh
+
+# Periodic job run on chromeos.kernelci.org to merge together all the pending
+# PRs and update the chromeos.kernelci.org branches, trigger a full build/test
+# cycle with a test kernel branch.
+
+set -e
+
+CHROMEOS_SETTINGS="data/chromeos.ini"
+SSH_KEY="keys/id_rsa_staging.kernelci.org"
+TAG_PREFIX='chromeos-'
+MAIN='chromeos'
+
+cmd_pull() {
+    echo "Updating local repository"
+    git pull --ff-only
+}
+
+cmd_jenkins() {
+    echo "Updating Jenkins jobs"
+    ./pending.py \
+        kernelci-jenkins \
+        --settings=${CHROMEOS_SETTINGS} \
+        --ssh-key=${SSH_KEY} \
+        --main=${MAIN} \
+        --tag-prefix=${TAG_PREFIX} \
+        --push
+}
+
+cmd_core() {
+    echo "Updating kernelci-core"
+    ./pending.py \
+        kernelci-core \
+        --settings=${CHROMEOS_SETTINGS} \
+        --ssh-key=${SSH_KEY} \
+        --main=${MAIN} \
+        --tag-prefix=${TAG_PREFIX} \
+        --push
+}
+
+cmd_test_definitions() {
+    echo "Updating test-definitions"
+    ./pending.py \
+        test-definitions \
+        --settings=${CHROMEOS_SETTINGS} \
+        --ssh-key=${SSH_KEY} \
+        --main=${MAIN} \
+        --tag-prefix=${TAG_PREFIX} \
+        --push
+}
+
+cmd_backend() {
+    echo "Updating kernelci-backend"
+    ./pending.py \
+        kernelci-backend \
+        --settings=${CHROMEOS_SETTINGS} \
+        --ssh-key=${SSH_KEY} \
+        --main=${MAIN} \
+        --tag-prefix=${TAG_PREFIX} \
+        --push
+
+    ./ansible \
+        kernelci-backend \
+        api.chromeos.kernelci.org \
+        chromeos.kernelci.org \
+        chromeos.kernelci.org \
+        $PWD/keys/id_rsa_kernelci.org
+}
+
+cmd_frontend() {
+    echo "Updating kernelci-frontend"
+    ./pending.py \
+        kernelci-frontend \
+        --settings=${CHROMEOS_SETTINGS} \
+        --ssh-key=${SSH_KEY} \
+        --main=${MAIN} \
+        --tag-prefix=${TAG_PREFIX} \
+        --push
+
+    ./ansible \
+        kernelci-frontend \
+        chromeos.kernelci.org \
+        chromeos.kernelci.org \
+        chromeos.kernelci.org \
+        $PWD/keys/id_rsa_kernelci.org
+}
+
+cmd_kernel() {
+    tree=stable
+    url=https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
+    branch=linux-5.12.y
+
+    echo "Pushing kernel test branch for ${tree}"
+    ./kernel.py \
+        --push \
+        --ssh-key=keys/id_rsa_staging.kernelci.org \
+        --from-url=$url \
+        --from-branch=$branch \
+        --branch=chromeos-"$tree" \
+        --tag-prefix=chromeos-"$tree"-
+}
+
+cmd_monitor() {
+    echo "Triggering Jenkins kernel-tree-monitor job"
+    python3 \
+        job.py \
+        --json=data/chromeos-monitor.json \
+        trigger \
+        chromeos/kernel-tree-monitor
+}
+
+cmd_all() {
+    tree="$1"
+
+    cmd_pull
+    cmd_jenkins
+    cmd_core
+    cmd_test_definitions
+    cmd_backend
+    cmd_frontend
+    cmd_kernel
+    cmd_monitor
+}
+
+cmd="${1}"
+
+if [ -n "$cmd" ]; then
+    shift 1
+else
+    cmd="all"
+fi
+
+"cmd_"$cmd $@
+
+exit 0

--- a/data/chromeos-monitor.json
+++ b/data/chromeos-monitor.json
@@ -1,0 +1,3 @@
+{
+    "CONFIG_LIST": "kernelci_chromeos-next kernelci_chromeos-mainline kernelci_chromeos-stable"
+}

--- a/data/chromeos.ini
+++ b/data/chromeos.ini
@@ -1,0 +1,33 @@
+[DEFAULT]
+branch: chromeos.kernelci.org
+namespace: kernelci
+users:
+    alexandrasp
+    crazoes
+    eballetbo
+    gctucker
+    hardboprobot
+    hiwang123
+    kernelci
+    krisman
+    Lakshmipathi
+    MyleneJ
+    mgalka
+    padovan
+    ribalda
+
+[bootrr]
+
+[buildroot]
+
+[kernelci-core]
+
+[kernelci-backend]
+
+[kernelci-frontend]
+
+[kernelci-jenkins]
+
+[kernelci-project]
+
+[test-definitions]


### PR DESCRIPTION
Add the chromeos.kernelci.org script to automatically deploy and run
jobs for the chromeos.kernelci.org instance.  Also include config
files needed to update the test branches and run Jenkins jobs.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>