### PR TITLE
patches/buildroot: use staging branch for bootrr

### DIFF
--- a/patches/buildroot/0001-STAGING-skip-hash-for-bootrr.patch
+++ b/patches/buildroot/0001-STAGING-skip-hash-for-bootrr.patch
@@ -1,0 +1,26 @@
+From 2aecc7754b56c7771f7635c7fe8ca0eb106b3fe4 Mon Sep 17 00:00:00 2001
+From: "kernelci.org bot" <bot@kernelci.org>
+Date: Thu, 18 Mar 2021 14:48:25 +0000
+Subject: [PATCH] STAGING skip hash for bootrr
+
+---
+ package/bootrr/bootrr.mk | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/package/bootrr/bootrr.mk b/package/bootrr/bootrr.mk
+index a4a321765c4c..041a94e681b4 100644
+--- a/package/bootrr/bootrr.mk
++++ b/package/bootrr/bootrr.mk
+@@ -5,7 +5,8 @@
+ ################################################################################
+ 
+ BOOTRR_SITE = https://github.com/kernelci/bootrr.git
+-BOOTRR_VERSION = 190921182ef98da0ff9028beff5beb367a6c26d9
++BOOTRR_VERSION = staging.kernelci.org
++BR_NO_CHECK_HASH_FOR += $(BOOTRR_SOURCE)
+ BOOTRR_SITE_METHOD = git
+ BOOTRR_LICENSE = LGPL-2.1+
+ 
+-- 
+2.20.1
+


### PR DESCRIPTION
Use the staging.kernelci.org branch when building bootrr and skip the
hash for staging since it's a moving target.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>