### PR TITLE
k8s builder deployment

### DIFF
--- a/k8s/aws/build-eksctl.yaml
+++ b/k8s/aws/build-eksctl.yaml
@@ -1,0 +1,56 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: kernelci-build-REGION
+  region: REGION
+  tags:
+    karpenter.sh/discovery: kernelbuild
+  version: "1.22"
+iam:
+  vpcResourceControllerPolicy: true
+  withOIDC: true
+  serviceAccounts:
+  - metadata:
+      name: efs-csi-controller-sa
+      namespace: kube-system
+    wellKnownPolicies:
+      efsCSIController: true
+  - metadata:
+      name: ebs-csi-controller-sa
+      namespace: kube-system
+    wellKnownPolicies:
+      ebsCSIController: true
+karpenter:
+  version: '0.9.0'
+  createServiceAccount: true
+kubernetesNetworkConfig:
+  ipFamily: IPv4
+availabilityZones:
+  - REGIONa
+  - REGIONb
+  - REGIONc
+managedNodeGroups:
+- name: service
+  desiredCapacity: 1
+  disableIMDSv1: false
+  disablePodIMDS: false
+  iam:
+    withAddonPolicies:
+      autoScaler: true
+      ebs: true
+  instanceSelector:
+    memory: "4"
+    vCPUs: 2
+  labels:
+    alpha.eksctl.io/cluster-name: kernelci-build-REGION
+    alpha.eksctl.io/nodegroup-name: service
+    kernelci.org/service: service
+  minSize: 1
+  maxSize: 3
+  privateNetworking: false
+  securityGroups:
+    withLocal: null
+    withShared: null
+  tags:
+    alpha.eksctl.io/nodegroup-name: service
+    alpha.eksctl.io/nodegroup-type: managed

--- a/k8s/aws/build-resources.yaml
+++ b/k8s/aws/build-resources.yaml
@@ -1,0 +1,54 @@
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: builder
+spec:
+  requirements:
+    - key: "topology.kubernetes.io/zone"
+      operator: In
+      values: [ "REGIONa", "REGIONb", "REGIONc" ]
+    - key: "karpenter.sh/capacity-type"
+      operator: In
+      values: [ "spot", "on-demand" ]
+    - key: "kubernetes.io/arch"
+      operator: In
+      values: [ "amd64" ]
+  limits:
+    resources:
+      cpu: 96
+  labels:
+     kernelci.org/builder: builder
+  provider:
+    subnetSelector:
+      karpenter.sh/discovery: kernelci-build-REGION
+    securityGroupSelector:
+      karpenter.sh/discovery: kernelci-build-REGION
+  ttlSecondsAfterEmpty: 30
+  ttlSecondsUntilExpired: 86400
+---
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: builder
+spec:
+  requirements:
+    - key: "topology.kubernetes.io/zone"
+      operator: In
+      values: [ "REGIONa", "REGIONb", "REGIONc" ]
+    - key: "karpenter.sh/capacity-type"
+      operator: In
+      values: [ "spot", "on-demand" ]
+    - key: "kubernetes.io/arch"
+      operator: In
+      values: [ "amd64" ]
+  limits:
+    resources:
+      cpu: 96
+  labels:
+     kernelci.org/service: service
+  provider:
+    subnetSelector:
+      karpenter.sh/discovery: kernelci-build-REGION
+    securityGroupSelector:
+      karpenter.sh/discovery: kernelci-build-REGION
+  ttlSecondsAfterEmpty: 30

--- a/k8s/aws/deploy-builder
+++ b/k8s/aws/deploy-builder
@@ -1,0 +1,22 @@
+#!/bin/sh -e
+
+REGION=${1}
+
+if [ "${REGION}" = "" ]; then
+	echo $0 REGION
+	exit 1
+fi
+
+if ! type eksctl > /dev/null ; then
+	echo eksctl not found
+	exit 1
+fi
+
+CLUSTER=kernelci-build-${REGION}.${REGION}.eksctl.io
+
+cat build-eksctl.yaml | sed s/REGION/${REGION}/g |
+	eksctl create cluster -f -
+cat build-resources.yaml | sed s/REGION/${REGION}/g |
+	kubectl --cluster ${CLUSTER} apply -f -
+
+../generic/deploy-builder

--- a/k8s/aws/teardown-builder
+++ b/k8s/aws/teardown-builder
@@ -1,0 +1,25 @@
+#!/bin/sh -e
+
+REGION=${1}
+
+if [ "${REGION}" = "" ]; then
+	echo $0 REGION
+	exit 1
+fi
+
+if ! type eksctl > /dev/null ; then
+	echo eksctl not found
+	exit 1
+fi
+
+CLUSTER=kernelci-build-${REGION}.${REGION}.eksctl.io
+
+../generic/teardown-builder
+
+# Clean up Karpenter and any remaining nodes
+kubectl --cluster ${CLUSTER} delete provisioner/builder
+for n in $(kubectl --cluster ${CLUSTER} get nodes -l karpenter.sh/provisioner-name --output name ); do
+        kubectl --cluster ${CLUSTER} delete ${n}
+done
+
+eksctl delete cluster kernelci-build-${REGION}

--- a/k8s/generic/deploy-builder
+++ b/k8s/generic/deploy-builder
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+kubectl apply -f ../generic/metrics-server.yaml

--- a/k8s/generic/metrics-server.yaml
+++ b/k8s/generic/metrics-server.yaml
@@ -1,0 +1,197 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: system:aggregated-metrics-reader
+rules:
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes/metrics
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: https
+  selector:
+    k8s-app: metrics-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        k8s-app: metrics-server
+    spec:
+      containers:
+      - args:
+        - --cert-dir=/tmp
+        - --secure-port=4443
+        - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+        - --kubelet-use-node-status-port
+        - --metric-resolution=15s
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
+        name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 20
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-dir
+      nodeSelector:
+        kubernetes.io/os: linux
+        kernelci.org/service: service
+      priorityClassName: system-cluster-critical
+      serviceAccountName: metrics-server
+      volumes:
+      - emptyDir: {}
+        name: tmp-dir
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: v1beta1.metrics.k8s.io
+spec:
+  group: metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: metrics-server
+    namespace: kube-system
+  version: v1beta1
+  versionPriority: 100

--- a/k8s/generic/teardown-builder
+++ b/k8s/generic/teardown-builder
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+#
+# Stub for now

--- a/k8s/minikube/deploy-builder
+++ b/k8s/minikube/deploy-builder
@@ -1,0 +1,13 @@
+#!/bin/sh -e
+
+minikube start
+minikube kubectl -- get pods -A
+
+# Don't use the minikube addon since cloud providers don't seem
+# to commonly have this automation so we do it generically...
+#minikube addons enable metrics-server
+
+kubectl label node/minikube kerneci.org/builder=builder
+kubectl label node/minikube kerneci.org/service=service
+
+../generic/deploy-builder

--- a/k8s/minikube/teardown-builder
+++ b/k8s/minikube/teardown-builder
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+../generic/teardown-builder
+minikube delete


### PR DESCRIPTION
This series adds some scripting for deploying builder clusters, mostly intended as a starting point for building on - at present everything is very crude but since we don't deploy services or otherwise much configure the clusters that's probably fine.

Currently there's no support for either Azure or Google Cloud so it's not actually useful for KernelCI itself yet. Azure's CLI doesn't work for AKS on Debian stable so while I have some scripting I've not really tested it.