### PR TITLE
chromeos.kernelci.org: Add building new docker images for ChromeOS

### DIFF
--- a/chromeos.kernelci.org
+++ b/chromeos.kernelci.org
@@ -102,13 +102,35 @@ cmd_kernel() {
 
 cmd_docker() {
     echo "Updating Docker images"
-    cd checkout/kernelci-core/config/docker-old
-    ./build-and-push.sh \
-        -p \
-        cros-baseline \
-        cros-qemu-modules \
-        cros-tast \
-        cros-sdk
+    # Build the images with kci_docker
+    cd checkout/kernelci-core/config/docker
+    core_rev=$(git show --pretty=format:%H -s origin/chromeos.kernelci.org)
+    rev_arg="--build-arg core_rev=$core_rev"
+    px_arg='--prefix=kernelci/cros-'
+    args="build --push $px_arg $rev_arg"
+
+    # KernelCI tools
+    ./kci_docker $args kernelci
+    ./kci_docker $args k8s $rev_arg --fragment=kernelci
+
+    # Compiler toolchains
+    for clang in clang-11 clang-14 clang-16; do
+	./kci_docker $args $clang $rev_arg --fragment=kselftest --fragment=kernelci
+    done
+    for arch in arm arm64 x86; do
+	./kci_docker $args gcc-10 --arch $arch $rev_arg \
+                     --fragment=kselftest --fragment=kernelci
+    done
+
+    px_arg='--prefix=kernelci/'
+    args="build --push $px_arg $rev_arg"
+    # ChromeOS related images
+    # cros-sdk used to create ChromiumOS rootfs, so it needs kernelci-core
+    # also we dont need cros- prefix as with compilers
+    ./kci_docker $args --fragment=kernelci cros-sdk
+    for imgname in cros-baseline cros-qemu-modules cros-tast; do
+	./kci_docker $args $rev_arg $imgname
+    done
     cd -
 }
 

--- a/patches/kernelci-jenkins/staging.kernelci.org/0004-STAGING-jobs.groovy-add-chromeos-jobs.patch
+++ b/patches/kernelci-jenkins/staging.kernelci.org/0004-STAGING-jobs.groovy-add-chromeos-jobs.patch
@@ -92,7 +92,7 @@ index 72e9480..a6c0cf1 100644
 +    stringParam('KCI_STORAGE_URL', 'http://storage.chromeos.kernelci.org', 'URL of the KernelCI storage server.')
 +    stringParam('KCI_CORE_URL', KCI_CORE_URL, 'URL of the kernelci-core repository.')
 +    stringParam('KCI_CORE_BRANCH', 'chromeos.kernelci.org', 'Name of the branch to use in the kernelci-core repository.')
-+    stringParam('DOCKER_BASE', KCI_DOCKER_BASE, 'Dockerhub base address used for the build images.')
++    stringParam('DOCKER_BASE', 'kernelci/cros-', 'Dockerhub base address used for the build images.')
 +    booleanParam('ALLOW_REBUILD', false, 'Allow building the same revision again.')
 +  }
 +}


### PR DESCRIPTION
As ChromeOS uses different set of docker images, we need to build them in deploy script.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>