### PR TITLE
staging.kernelci.org: Remove kernelci fragment

### DIFF
--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -196,8 +196,8 @@ cmd_docker() {
     ./kci_docker $args gcc-10 --arch x86 --fragment=kunit --fragment=kernelci
 
     # rootfs
-    ./kci_docker $args buildroot --fragment=kernelci
-    ./kci_docker $args debos --fragment=kernelci
+    ./kci_docker $args buildroot
+    ./kci_docker $args debos
 
     # QEMU
     ./kci_docker $args qemu


### PR DESCRIPTION
At current moment we decided to keep rootfs built old way, with git clone (without using fragment).
Additionally debos have conflicts on pyyaml versions with kernelci-core tools, so fragment need to be removed for now to fix staging.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>