### PR TITLE
staging.kernelci.org: Add --no-cache argument

### DIFF
--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -173,10 +173,25 @@ cmd_docker() {
 
     # Build the images with kci_docker
     cd checkout/kernelci-core/config/docker
+
+    # Build without cache if flag file doesn't exist or older than x days
+    purge_flag_file=".last_docker_purge"
+    if [ -f "$purge_flag_file" ]; then
+        flag_time=$(date -r "$purge_flag_file" +%s)
+        week_ago=$(date -d 'now - 7 days' +%s)
+    fi
+    if [ ! -f "$purge_flag_file" ] || (( flag_time <= week_ago )); then
+        echo "Building without cache"
+        cache_arg="--no-cache"
+        touch "$purge_flag_file"
+    else
+        cache_arg=""
+    fi
+
     core_rev=$(git show --pretty=format:%H -s origin/staging.kernelci.org)
     rev_arg="--build-arg core_rev=$core_rev"
     px_arg='--prefix=kernelci/staging-'
-    args="build --push $px_arg $rev_arg"
+    args="build --push $px_arg $cache_arg $rev_arg"
 
     # KernelCI tools
     ./kci_docker $args kernelci


### PR DESCRIPTION
As in production, we need to have no-cache argument to have Docker containers content properly updated.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>