### PR TITLE
kernelci.org: Remove kernelci fragment from debos image

### DIFF
--- a/kernelci.org
+++ b/kernelci.org
@@ -217,7 +217,7 @@ cmd_docker() {
 
     # rootfs
     ./kci_docker $args buildroot --fragment=kernelci
-    ./kci_docker $args debos --fragment=kernelci
+    ./kci_docker $args debos
 
     # QEMU
     ./kci_docker $args qemu


### PR DESCRIPTION
Debos at the moment is never used with kernelci-core installed internally as rootfs images for KernelCI are always build with the kernelci-core from the HEAD of the main branch.
Leaving pyyaml installed from the debian package and with pip during kernelci-core installation crashes docker image builds.
