### PR TITLE
kernelci.org: Remove workaround for kci_test update_rootfs_urls

### DIFF
--- a/kernelci.org
+++ b/kernelci.org
@@ -92,7 +92,7 @@ cmd_rootfs_update() {
     cd checkout/kernelci-core
     git fetch origin main
     git checkout $FETCH_HEAD
-    if ./kci_test update_rootfs_urls --release ${version} --output rootfs-images-${version}.yaml --verbose | grep OK; then
+    if ./kci_test update_rootfs_urls --release ${version} --output rootfs-images-${version}.yaml --verbose; then
         mv rootfs-images-${version}.yaml config/core/rootfs-images.yaml
         local branch=rootfs-$version
         git checkout -b $branch


### PR DESCRIPTION
kci_test update_rootfs_urls was returining invalid exit code, hence a workaround was applied to determine command's pass/fail state. As kci_test exit code issue is fixed the workaround can be removed.

Depends on https://github.com/kernelci/kernelci-core/pull/1545