### PR TITLE
kernelci.org/staging.kernelci.org: Add building rustc docker image

### DIFF
--- a/kernelci.org
+++ b/kernelci.org
@@ -214,6 +214,7 @@ cmd_docker() {
     ./kci_docker $args gcc-10 --arch sparc --fragment=kernelci
     # only x86 is useful for KUnit (for now)
     ./kci_docker $args gcc-10 --arch x86 --fragment=kunit --fragment=kernelci
+    ./kci_docker $args rustc-1.62 --fragment=kselftest --fragment=kernelci
 
     # rootfs
     ./kci_docker $args buildroot --fragment=kernelci

--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -209,6 +209,7 @@ cmd_docker() {
     ./kci_docker $args gcc-10 --arch sparc --fragment=kernelci
     # only x86 is useful for KUnit (for now)
     ./kci_docker $args gcc-10 --arch x86 --fragment=kunit --fragment=kernelci
+    ./kci_docker $args rustc-1.62 --fragment=kselftest --fragment=kernelci
 
     # rootfs
     ./kci_docker $args buildroot


### PR DESCRIPTION
Rust toolchain docker image recipe has been added recently. This commit adds this image to be build during production and staging updates.
