### PR TITLE
kernelci.org: Limit rootfs builds to buildroot and debos types

### DIFF
--- a/kernelci.org
+++ b/kernelci.org
@@ -68,7 +68,8 @@ cmd_rootfs_builds() {
 
     echo "{\
 \"PIPELINE_VERSION\": \"$version\",\
-\"KCI_CORE_BRANCH\": \"main\"\
+\"KCI_CORE_BRANCH\": \"main\",\
+\"ROOTFS_TYPE\": \"buildroot debos\"\
 }" > rootfs-build-trigger.json
     python3 job.py \
         --settings=data/prod-jenkins.ini \


### PR DESCRIPTION
During weekly production updates only debos and buildroot rootfs images are built.
Add ROOTFS_TYPE parameter to make sure that others are not build when kernelci.org rootfs command is called.
