### PR TITLE
staging.kernelci.org: Fix "source" branch name

### DIFF
--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -65,8 +65,8 @@ cmd_buildroot() {
 
 cmd_test_definitions() {
     echo "Updating test-definitions"
-    ./pending.py test-definitions --push
-    ./pending.py iec-security --push
+    ./pending.py test-definitions --main=kernelci.org --push
+    ./pending.py iec-security --main=kernelci.org --push
 }
 
 cmd_kcidb() {


### PR DESCRIPTION
update.py by default fetch main branch, while for iec-security and test-definitions we use kernelci.org branch for rebasing. As result these 2 repositories was not tested on staging. Add argument --main that will specify "source" branch to merge pending PR with it.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>