### PR TITLE
staging.kernelci.org: Build architecure specific clang containers

### DIFF
--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -200,6 +200,10 @@ cmd_docker() {
     # Compiler toolchains
     for clang in clang-11 clang-14 clang-16; do
 	./kci_docker $args $clang --fragment=kselftest --fragment=kernelci
+        for arch in arm arm64 mips riscv x86; do
+	    ./kci_docker $args $clang --arch $arch \
+-                    --fragment=kselftest --fragment=kernelci
+        done
     done
     for arch in arc arm armv5 arm64 mips riscv64 x86; do
 	./kci_docker $args gcc-10 --arch $arch \


### PR DESCRIPTION
As part of enabling coverage of kselftest for clang builds archiecture specific Docker containers are being added containing libraries needed to build real userspace applications.  Include these in the set of containers we build for staging, leaving the existing containers in place to avoid disrupting existing usage.

Similar updates will be needed to the production script to deploy this but to minimise the risk of disruption there those will be done separately if this approach progresses.

Signed-off-by: Mark Brown <broonie@kernel.org>