### PR TITLE
staging.kernelci.org: Small leftover character fix and arch

### DIFF
--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -200,9 +200,9 @@ cmd_docker() {
     # Compiler toolchains
     for clang in clang-11 clang-14 clang-16; do
 	./kci_docker $args $clang --fragment=kselftest --fragment=kernelci
-        for arch in arm arm64 mips riscv x86; do
+        for arch in arm arm64 mips riscv64 x86; do
 	    ./kci_docker $args $clang --arch $arch \
--                    --fragment=kselftest --fragment=kernelci
+                     --fragment=kselftest --fragment=kernelci
         done
     done
     for arch in arc arm armv5 arm64 mips riscv64 x86; do


### PR DESCRIPTION
One danging - left unnoticed and need to be removed. Also in https://github.com/kernelci/kernelci-core/pull/1640 we have riscv64 fragment, not riscv, correct in docker generation arch name.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>