### PR TITLE
kernelci.org: build arch-specific clang Docker images

### DIFF
--- a/kernelci.org
+++ b/kernelci.org
@@ -197,7 +197,8 @@ cmd_docker() {
     cd checkout/kernelci-core/config/docker
 
     core_rev=$(git show --pretty=format:%H -s origin/kernelci.org)
-    args="build --push --no-cache --build-arg core_rev=$core_rev"
+    base_args="build --build-arg core_rev=$core_rev"
+    args="$base_args --push --no-cache"
 
     # KernelCI tools
     ./kci_docker $args kernelci
@@ -205,9 +206,11 @@ cmd_docker() {
 
     # Compiler toolchains
     for clang in clang-11 clang-12 clang-13 clang-14 clang-15 clang-16; do
-	./kci_docker $args $clang --fragment=kselftest --fragment=kernelci
-        for arch in arm arm64 mips riscv64 x86; do
-	    ./kci_docker $args $clang --arch $arch \
+	./kci_docker $args $clang
+    done
+    for clang in clang-11 clang-15 clang-16; do
+        for arch in arm arm64 armv5 mips riscv64 x86; do
+	    ./kci_docker $base_args --push $clang --arch $arch \
                      --fragment=kselftest --fragment=kernelci
         done
     done

--- a/kernelci.org
+++ b/kernelci.org
@@ -206,6 +206,10 @@ cmd_docker() {
     # Compiler toolchains
     for clang in clang-11 clang-12 clang-13 clang-14 clang-15 clang-16; do
 	./kci_docker $args $clang --fragment=kselftest --fragment=kernelci
+        for arch in arm arm64 mips riscv64 x86; do
+	    ./kci_docker $args $clang --arch $arch \
+                     --fragment=kselftest --fragment=kernelci
+        done
     done
     for arch in arc arm armv5 arm64 mips riscv64 x86; do
 	./kci_docker $args gcc-10 --arch $arch \

--- a/kernelci.org
+++ b/kernelci.org
@@ -197,7 +197,7 @@ cmd_docker() {
     cd checkout/kernelci-core/config/docker
 
     core_rev=$(git show --pretty=format:%H -s origin/kernelci.org)
-    args="build --push --verbose --no-cache --build-arg core_rev=$core_rev"
+    args="build --push --no-cache --build-arg core_rev=$core_rev"
 
     # KernelCI tools
     ./kci_docker $args kernelci


### PR DESCRIPTION
Update the `cmd_docker()` function to build the arch-specific Clang images as well as the base ones with just the toolchain.