### PR TITLE
chromeos.kernelci.org: use 6.1 LTS for chromeos-stable

### DIFF
--- a/chromeos.kernelci.org
+++ b/chromeos.kernelci.org
@@ -140,7 +140,7 @@ cmd_kernel() {
         --push \
         --ssh-key=keys/id_rsa_staging.kernelci.org \
         --from-url=https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git \
-        --from-branch=linux-5.15.y \
+        --from-branch=linux-6.1.y \
         --branch=chromeos-stable \
         --tag-prefix=chromeos-stable-
 }


### PR DESCRIPTION
Move the base version for chromeos-stable from 5.15 to 6.1 LTS which is more relevant with the tests we're running now.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>