### PR TITLE
chromeos.kernelci.org: Update clang list to actually required versions

### DIFF
--- a/chromeos.kernelci.org
+++ b/chromeos.kernelci.org
@@ -114,7 +114,7 @@ cmd_docker() {
     ./kci_docker $args k8s $rev_arg --fragment=kernelci
 
     # Compiler toolchains
-    for clang in clang-11 clang-14 clang-16; do
+    for clang in clang-13 clang-14; do
 	./kci_docker $args $clang $rev_arg \
 		     --fragment=kselftest --fragment=kernelci
 	for arch in arm arm64 x86; do


### PR DESCRIPTION
Previous commit included invalid versions of clang. Update list based on config and k8s queue observation

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>