### PR TITLE
chromeos.kernelci.org: One more update of clang compilers

### DIFF
--- a/chromeos.kernelci.org
+++ b/chromeos.kernelci.org
@@ -114,7 +114,7 @@ cmd_docker() {
     ./kci_docker $args k8s $rev_arg --fragment=kernelci
 
     # Compiler toolchains
-    for clang in clang-13 clang-14; do
+    for clang in clang-14; do
 	./kci_docker $args $clang $rev_arg \
 		     --fragment=kselftest --fragment=kernelci
 	for arch in arm arm64 x86; do


### PR DESCRIPTION
I was confused by k8s list of failed pods, and just figured out that failed clang-13 image with cros fragment is not related to chromeos.kernelci.org instance.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>