### PR TITLE
chromeos-monitor.json: Remove from ChromeOS tests kernel 5.10

### DIFF
--- a/data/chromeos-monitor.json
+++ b/data/chromeos-monitor.json
@@ -1,3 +1,3 @@
 {
-    "CONFIG_LIST": "chromeos-stable_5.10 chromeos-stable_5.15 kernelci_chromeos-stable"
+    "CONFIG_LIST": "chromeos-stable_5.15 kernelci_chromeos-stable"
 }


### PR DESCRIPTION
Kernel 5.10 is no more relevant for ChromeOS testing, remove it from jenkins monitor.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>