### PR TITLE
Clang 17 updates

### DIFF
--- a/kernelci.org
+++ b/kernelci.org
@@ -205,10 +205,10 @@ cmd_docker() {
     ./kci_docker $args k8s --fragment=kernelci
 
     # Compiler toolchains
-    for clang in clang-11 clang-12 clang-13 clang-14 clang-15 clang-16; do
+    for clang in clang-11 clang-12 clang-13 clang-14 clang-15 clang-16 clang-17; do
 	./kci_docker $args $clang
     done
-    for clang in clang-11 clang-14 clang-15 clang-16; do
+    for clang in clang-11 clang-14 clang-15 clang-16 clang-17; do
         for arch in arm arm64 armv5 mips riscv64 x86; do
 	    ./kci_docker $base_args --push $clang --arch $arch \
                      --fragment=kselftest --fragment=kernelci

--- a/patches/kernelci-core/staging.kernelci.org/0001-STAGING-add-build-configs-staging.yaml.patch
+++ b/patches/kernelci-core/staging.kernelci.org/0001-STAGING-add-build-configs-staging.yaml.patch
@@ -86,9 +86,9 @@ index 00000000..56eb40d4
 +    arm64: *arm64_defconfig
 +    x86_64: *x86_64_defconfig-staging
 +
-+staging-clang-16: &staging-clang-16
++staging-clang-17: &staging-clang-17
 +  <<: *staging-clang-11
-+  build_environment: clang-16
++  build_environment: clang-17
 +
 +
 +build_configs:
@@ -98,7 +98,7 @@ index 00000000..56eb40d4
 +    branch: 'staging-android'
 +    variants:
 +      gcc-10: *staging-gcc-10
-+      clang-16: *staging-clang-16
++      clang-17: *staging-clang-17
 +
 +  kernelci_staging-cip:
 +    tree: kernelci
@@ -118,7 +118,7 @@ index 00000000..56eb40d4
 +    branch: 'staging-next'
 +    variants:
 +      gcc-10: *staging-gcc-10
-+      clang-16: *staging-clang-16
++      clang-17: *staging-clang-17
 +
 +  kernelci_staging-stable:
 +    tree: kernelci

--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -198,7 +198,7 @@ cmd_docker() {
     ./kci_docker $args k8s $rev_arg --fragment=kernelci
 
     # Compiler toolchains
-    for clang in clang-11 clang-14 clang-16; do
+    for clang in clang-11 clang-14 clang-17; do
 	./kci_docker $args $clang --fragment=kselftest --fragment=kernelci
         for arch in arm arm64 mips riscv64 x86; do
 	    ./kci_docker $args $clang --arch $arch \


### PR DESCRIPTION
Series of updates required to update production to clang-17 and testing it (and keep) on staging as well.

Related: https://github.com/kernelci/kernelci-core/pull/1701