### PR TITLE
chormeos.kernelci.org: Remove surplus cmd_kernel function

### DIFF
--- a/chromeos.kernelci.org
+++ b/chromeos.kernelci.org
@@ -85,21 +85,6 @@ cmd_frontend() {
         $PWD/keys/id_rsa_kernelci.org
 }
 
-cmd_kernel() {
-    tree=mainline
-    url=git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
-    branch=master
-
-    echo "Pushing kernel test branch for ${tree}"
-    ./kernel.py \
-        --push \
-        --ssh-key=keys/id_rsa_staging.kernelci.org \
-        --from-url=$url \
-        --from-branch=$branch \
-        --branch=chromeos-"$tree" \
-        --tag-prefix=chromeos-"$tree"-
-}
-
 cmd_docker() {
     echo "Updating Docker images"
     # Build the images with kci_docker


### PR DESCRIPTION
First declaration of of cmd_function looks like a definition that doesn't belong to cheomroes.kernelci.org script. It doesn't break anything, but affects readability. Remove the surplus code.