### PR TITLE
build-configs.yaml: Add kselftest-slim to the staging build configs

### DIFF
--- a/patches/kernelci-core/staging.kernelci.org/0001-STAGING-add-build-configs-staging.yaml.patch
+++ b/patches/kernelci-core/staging.kernelci.org/0001-STAGING-add-build-configs-staging.yaml.patch
@@ -50,7 +50,7 @@ index 00000000..56eb40d4
 +# Staging build configurations using GCC
 +staging-gcc-10: &staging-gcc-10
 +  build_environment: gcc-10
-+  fragments: [kselftest]
++  fragments: [kselftest, kselftest-slim]
 +  architectures:
 +    arc: *arc_defconfig
 +    arm:
@@ -80,7 +80,7 @@ index 00000000..56eb40d4
 +# Staging build configurations using LLVM/Clang
 +staging-clang-11: &staging-clang-11
 +  build_environment: clang-11
-+  fragments: [kselftest]
++  fragments: [kselftest, kselftest-slim]
 +  architectures:
 +    arm: *arm_defconfig
 +    arm64: *arm64_defconfig


### PR DESCRIPTION
There's a PR against kernelci-core introducing a new virtual fragment
for kselftest which cuts out the fragments that mainly contribute to
bloating the size and tanking the performance of the image.
