### PR TITLE
__init__.py: Enable optional Github token support

### DIFF
--- a/kernelci/__init__.py
+++ b/kernelci/__init__.py
@@ -36,7 +36,12 @@ COLORS = {
 }
 
 # Github API handler
-GITHUB = github.Github()
+# If keys/gh-token.txt exists, use it as a token, otherwise use without auth
+if os.path.isfile('keys/gh-token.txt'):
+    with open('keys/gh-token.txt', 'r') as f:
+        GITHUB = github.Github(login_or_token=f.read().strip())
+else:
+    GITHUB = github.Github()
 
 
 def print_color(color, msg):


### PR DESCRIPTION
This commit adds functionality to the code to check for the presence of a GitHub access token in the keys/gh-token.txt file. If the token is present, it will be used to raise the rate limits for GitHub API requests. If the token is not present, the code will continue to behave as before without raising the rate limits.

This change should help to avoid hitting the rate
limits when making multiple API requests to GitHub.