### PR TITLE
chromeos.ini: Add nfraprado to trusted users in CHROMEOS

### DIFF
--- a/data/chromeos.ini
+++ b/data/chromeos.ini
@@ -11,6 +11,7 @@ users:
     kernelci
     krisman
     mgalka
+    nfraprado
     nuclearcat
     padovan
     ribalda


### PR DESCRIPTION
nfraprado(Nícolas F. R. A. Prado) is already trusted contributor on main branch, but missing in ChromeOS branch.
Adding him on ChromeOS as he have pending patches that need to be tested on staging.