### PR TITLE
chromeos-monitor.json: Add new kernel to monitor job

### DIFF
--- a/data/chromeos-monitor.json
+++ b/data/chromeos-monitor.json
@@ -1,3 +1,3 @@
 {
-    "CONFIG_LIST": "chromeos-stable_5.15 chromeos-stable_6.1 kernelci_chromeos-stable"
+    "CONFIG_LIST": "chromeos-stable_5.15 chromeos-stable_6.1 kernelci_chromeos-stable collabora-chromeos-kernel"
 }


### PR DESCRIPTION
As we added new kernel, collabora-chromeos-kernel, we need to monitor it as well for changes and if any, it will run tests.