### PR TITLE
T41052 Replace `kci_docker` with `kci docker`

### DIFF
--- a/kernelci.org
+++ b/kernelci.org
@@ -194,51 +194,49 @@ cmd_website() {
 cmd_docker() {
     echo "Re-building Docker images"
 
-    cd checkout/kernelci-core/config/docker
+    cd checkout/kernelci-core
 
     core_rev=$(git show --pretty=format:%H -s origin/kernelci.org)
     base_args="build --build-arg core_rev=$core_rev"
     args="$base_args --push --no-cache"
 
     # KernelCI tools
-    ./kci_docker $args kernelci
-    ./kci_docker $args k8s --fragment=kernelci
+    ./kci docker $args kernelci
+    ./kci docker $args k8s kernelci
 
     # Compiler toolchains
     for clang in clang-11 clang-12 clang-13 clang-14 clang-15 clang-16 clang-17; do
-	./kci_docker $args $clang
+	./kci docker $args $clang
     done
     for clang in clang-11 clang-14 clang-15 clang-16 clang-17; do
         for arch in arm arm64 armv5 mips riscv64 x86; do
-	    ./kci_docker $base_args --push $clang --arch $arch \
-                     --fragment=kselftest --fragment=kernelci
+	    ./kci docker $base_args --push $clang kselftest kernelci --arch $arch
         done
     done
     for arch in arc arm armv5 arm64 mips riscv64 x86; do
-	./kci_docker $args gcc-10 --arch $arch \
-                     --fragment=kselftest --fragment=kernelci
+	./kci docker $args gcc-10 kselftest kernelci --arch $arch
     done
     # missing -dev packages for sparc64
-    ./kci_docker $args gcc-10 --arch sparc --fragment=kernelci
+    ./kci docker $args gcc-10 kernelci --arch sparc
     # only x86 is useful for KUnit (for now)
-    ./kci_docker $args gcc-10 --arch x86 --fragment=kunit --fragment=kernelci
+    ./kci docker $args gcc-10 kunit kernelci --arch x86
     for rustc in rustc-1.62 rustc-1.66; do
-        ./kci_docker $args $rustc --fragment=kselftest --fragment=kernelci
+        ./kci docker $args $rustc kselftest kernelci
         for arch in x86; do
-            ./kci_docker $args $rustc --arch $arch --fragment=kselftest --fragment=kernelci
+            ./kci docker $args $rustc kselftest kernelci --arch $arch
         done
     done
 
     # rootfs
-    ./kci_docker $args buildroot --fragment=kernelci
-    ./kci_docker $args debos --fragment=kernelci
+    ./kci docker $args buildroot kernelci
+    ./kci docker $args debos kernelci
 
     # QEMU
-    ./kci_docker $args qemu
+    ./kci docker $args qemu
 
     # Other tools
-    ./kci_docker $args cvehound --fragment=kernelci
-    ./kci_docker $args dt-validation # --fragment=kernelci (PyYAML conflict)
+    ./kci docker $args cvehound kernelci
+    ./kci docker $args dt-validation # kernelci (PyYAML conflict)
 
     cd -
 }

--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -185,8 +185,8 @@ cmd_docker() {
         cache_arg=""
     fi
 
-    # Build the images with kci_docker
-    cd checkout/kernelci-core/config/docker
+    # Build the images with kci docker
+    cd checkout/kernelci-core
 
     core_rev=$(git show --pretty=format:%H -s origin/staging.kernelci.org)
     rev_arg="--build-arg core_rev=$core_rev"
@@ -194,39 +194,37 @@ cmd_docker() {
     args="build --push $px_arg $cache_arg $rev_arg"
 
     # KernelCI tools
-    ./kci_docker $args kernelci
-    ./kci_docker $args k8s $rev_arg --fragment=kernelci
+    ./kci docker $args kernelci
+    ./kci docker $args k8s kernelci $rev_arg
 
     # Compiler toolchains
     for clang in clang-11 clang-14 clang-17; do
-	./kci_docker $args $clang --fragment=kselftest --fragment=kernelci
+	./kci docker $args $clang kselftest kernelci
         for arch in arm arm64 mips riscv64 x86; do
-	    ./kci_docker $args $clang --arch $arch \
-                     --fragment=kselftest --fragment=kernelci
+	    ./kci docker $args $clang kselftest kernelci --arch $arch
         done
     done
     for arch in arc arm armv5 arm64 mips riscv64 x86; do
-	./kci_docker $args gcc-10 --arch $arch \
-                     --fragment=kselftest --fragment=kernelci
+	./kci docker $args gcc-10 kselftest kernelci --arch $arch
     done
     # missing -dev packages for sparc64
-    ./kci_docker $args gcc-10 --arch sparc --fragment=kernelci
+    ./kci docker $args gcc-10 kernelci --arch sparc
     # only x86 is useful for KUnit (for now)
-    ./kci_docker $args gcc-10 --arch x86 --fragment=kunit --fragment=kernelci
+    ./kci docker $args gcc-10 kunit kernelci --arch x86
     for rustc in rustc-1.62 rustc-1.66; do
-    ./kci_docker $args $rustc --fragment=kselftest --fragment=kernelci
+    ./kci docker $args $rustc kselftest kernelci
     done
 
     # rootfs
-    ./kci_docker $args buildroot --fragment=kernelci
-    ./kci_docker $args debos --fragment=kernelci
+    ./kci docker $args buildroot kernelci
+    ./kci docker $args debos kernelci
 
     # QEMU
-    ./kci_docker $args qemu
+    ./kci docker $args qemu
 
     # Other tools
-    ./kci_docker $args cvehound --fragment=kernelci
-    ./kci_docker $args dt-validation # --fragment=kernelci (PyYAML conflict)
+    ./kci docker $args cvehound kernelci
+    ./kci docker $args dt-validation # kernelci (PyYAML conflict)
     cd -
 }
 


### PR DESCRIPTION
Since the script `kci_docker` to create and build docker images has been converted to `kci docker` command, replace the script with `kci` command in the `kernelci.org` and `staging.kernelci.org` tools.