### PR TITLE
staging.kernelci.org: Add kernelci fragment to debos and buildroot

### DIFF
--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -218,8 +218,8 @@ cmd_docker() {
     done
 
     # rootfs
-    ./kci_docker $args buildroot
-    ./kci_docker $args debos
+    ./kci_docker $args buildroot --fragment=kernelci
+    ./kci_docker $args debos --fragment=kernelci
 
     # QEMU
     ./kci_docker $args qemu


### PR DESCRIPTION
Jenkins require to use docker images with kernelci fragment, and we are building without, as result jenkins use outdated images.