### PR TITLE
pending.py: Include PRs with staging:<main_branch> labels

### DIFF
--- a/pending.py
+++ b/pending.py
@@ -61,6 +61,7 @@ def iterate_prs(repo, skip, users, path):
         repo = pr.head.repo
         user = pr.head.repo.owner.login if repo else "(unknown)"
         labels = list(label.name for label in pr.labels)
+        include_label = 'staging:{}'.format(args.main)
         print("{:4} {:16} {:32} ".format(pr.number, user, branch), end='')
         if repo is None:
             print_color('red', "SKIP unknown repository")
@@ -68,10 +69,10 @@ def iterate_prs(repo, skip, users, path):
             print_color('red', "SKIP untrusted user")
         elif (user, branch) in skip:
             print_color('yellow', "SKIP")
-        elif pr.base.ref != args.main:
-            print_color('yellow', "SKIP base: {}".format(pr.base.ref))
         elif args.skip_label and args.skip_label in labels:
             print_color('yellow', "SKIP label: {}".format(args.skip_label))
+        elif pr.base.ref != args.main and include_label not in labels:
+            print_color('yellow', "SKIP base: {} labels: {}".format(pr.base.ref, labels))
         else:
             if pull(args, pr, path):
                 print_color('green', "OK")


### PR DESCRIPTION
 Introduce a way to add to staging PRs from branches other than  the one specified in the --main option.
    
Apart from PRs with a base branch name specified in --main also PRs based on different labels having "staging:<main_branch>" labels will be  merged. <main_branch> is the branch name specified in the --main option.
    
E.g.
    
To merge PR based on different barnch to chromeos branch it's enough to  mark it with "staging:chromeos" branch.