### PR TITLE
T41052 kernelci.org: add `prefix` argument for `docker` command

### DIFF
--- a/kernelci.org
+++ b/kernelci.org
@@ -198,7 +198,7 @@ cmd_docker() {
 
     core_rev=$(git show --pretty=format:%H -s origin/kernelci.org)
     base_args="build --build-arg core_rev=$core_rev"
-    args="$base_args --push --no-cache"
+    args="$base_args --prefix=kernelci/ --push --no-cache"
 
     # KernelCI tools
     ./kci docker $args kernelci


### PR DESCRIPTION
Fix below error for `docker` command by adding prefix argument:
"The following arguments or settings are required: --prefix"