### PR TITLE
0002-CHROMEOS...patch: Update ChromeOS tests, trees, logic

### DIFF
--- a/patches/kernelci-jenkins/chromeos.kernelci.org/0002-CHROMEOS-only-send-emails-for-kernelci-tree.patch
+++ b/patches/kernelci-jenkins/chromeos.kernelci.org/0002-CHROMEOS-only-send-emails-for-kernelci-tree.patch
@@ -1,28 +1,42 @@
 From b185cd831ecf5dc272334dfb76e2177cff1be4d6 Mon Sep 17 00:00:00 2001
 From: "kernelci.org bot" <bot@kernelci.org>
-Date: Thu, 30 Jan 2020 14:33:44 +0000
-Subject: [PATCH 2/2] CHROMEOS only send emails for kernelci tree
+Date: Thu, 32 Apr 2023 14:33:44 +0000
+Subject: [PATCH 2/2] CHROMEOS for kernelci emails fix
 
----
- scripts/kernel-arch-complete.sh | 5 +++++
- 1 file changed, 5 insertions(+)
-
-diff --git a/scripts/kernel-arch-complete.sh b/scripts/kernel-arch-complete.sh
-index 3be017318a8e..60e9b98d2682 100755
 --- a/scripts/kernel-arch-complete.sh
 +++ b/scripts/kernel-arch-complete.sh
-@@ -35,6 +35,11 @@ fi
+@@ -35,6 +35,34 @@
      echo "Build has now finished, reporting result to dashboard."
      curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'"}' ${API}/job
  
-+if [ "$TREE_NAME" != "kernelci" ]; then
-+    echo "Only dealing with kernelci tree on chromeos.kernelci.org for now"
++# In ChromeOS we send results to staging only
++if [ "$TREE_NAME" == "kernelci" ] || [ "$TREE_NAME" == "collabora-chromeos-kernel" ]; then
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'", "build_report": 1, "format": ["txt"], "send_to": ["kernelci-results-staging@groups.io"], "delay": 0}' ${API}/send
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "baseline", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 1800}' ${API}/send
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "baseline-nfs", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 1800}' ${API}/send
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "baseline-fastboot", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 1800}' ${API}/send
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "v4l2-compliance-vivid", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 2700}' ${API}/send
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "v4l2-compliance-uvc", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 2700}' ${API}/send
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "igt-kms-exynos", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 2700}' ${API}/send
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "igt-kms-rockchip", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 2700}' ${API}/send
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "igt-kms-tegra", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 2700}' ${API}/send
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "igt-gpu-panfrost", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 2700}' ${API}/send
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "cros-ec", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 2700}' ${API}/send
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "sleep", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 2700}' ${API}/send
++    # Tast tests
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "cros-tast-kernel", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 2700}' ${API}/send
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "cros-tast-mm-decode", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 2700}' ${API}/send
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "cros-tast-mm-encode", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 2700}' ${API}/send
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "cros-tast-mm-misc", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 2700}' ${API}/send
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "cros-tast-perf", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 2700}' ${API}/send
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "cros-tast-platform", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 2700}' ${API}/send
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "cros-tast-sound", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 2700}' ${API}/send
++    curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'",  "report_type": "test", "plan": "cros-tast-video", "send_to": ["kernelci-results-staging@groups.io"], "format": ["txt"], "delay": 2700}' ${API}/send
++    # Don't go anywhere else!
 +    exit 0
 +fi
++exit 0
 +
      if [ "$EMAIL" != "true" ]; then
          echo "Not sending emails because EMAIL was false"
          exit 0
--- 
-2.20.1
-


### PR DESCRIPTION
First we need to add new tast tests.
Second we need to send more results to staging maillist, and do not process also other emails, to make sure we wont litter anywhere else with ChromeOS instance results. Third we need to add new kernel tree.