### PR TITLE
chromeos-monitor.json: Add chromeos-stable_6.1-backported-arm64

### DIFF
--- a/data/chromeos-monitor.json
+++ b/data/chromeos-monitor.json
@@ -1,3 +1,3 @@
 {
-    "CONFIG_LIST": "chromeos-stable_5.15 chromeos-stable_6.1 kernelci_chromeos-stable collabora-chromeos-kernel"
+    "CONFIG_LIST": "chromeos-stable_5.15 chromeos-stable_6.1 kernelci_chromeos-stable collabora-chromeos-kernel chromeos-stable_6.1-backported-arm64"
 }


### PR DESCRIPTION
Add the chromeos-stable_6.1-backported-arm64 build to the monitor, so it actually builds and gets tested when the branch is updated.