### PR TITLE
patches/kernelci-pipeline: patch for adding TOML settings file

### DIFF
--- a/patches/kernelci-pipeline/staging.kernelci.org/0001-STAGING-config-staging.kernelci.org.toml-add-file-fo.patch
+++ b/patches/kernelci-pipeline/staging.kernelci.org/0001-STAGING-config-staging.kernelci.org.toml-add-file-fo.patch
@@ -1,0 +1,55 @@
+From 718fedfaad4b5afa14859f1570a97a97ae1b45fd Mon Sep 17 00:00:00 2001
+From: "kernelci.org bot" <bot@kernelci.org>
+Date: Thu, 25 May 2023 12:13:46 +0530
+Subject: [PATCH] STAGING config/staging.kernelci.org.toml: add file for
+ staging
+
+---
+ config/staging.kernelci.org.toml | 35 ++++++++++++++++++++++++++++++++
+ 1 file changed, 35 insertions(+)
+ create mode 100644 config/staging.kernelci.org.toml
+
+diff --git a/config/staging.kernelci.org.toml b/config/staging.kernelci.org.toml
+new file mode 100644
+index 0000000..1cc7282
+--- /dev/null
++++ b/config/staging.kernelci.org.toml
+@@ -0,0 +1,35 @@
++[DEFAULT]
++api_config = "staging.kernelci.org"
++storage_config = "staging.kernelci.org"
++verbose = true
++
++[trigger]
++poll_period = 3600
++startup_delay = 3
++
++[tarball]
++kdir = "/home/kernelci/data/src/linux"
++output = "/home/kernelci/data/output"
++storage_config = "staging.kernelci.org"
++
++[runner]
++output = "/home/kernelci/data/output"
++runtime_config = "k8s-gke-eu-west4"
++
++[notifier]
++
++[send_kcidb]
++kcidb_topic_name = "playground_kcidb_new"
++kcidb_project_id = "kernelci-production"
++origin = "kernelci_api"
++
++[test_report]
++smtp_host = "smtp.gmail.com"
++smtp_port =  465
++
++[timeout]
++
++[regression_tracker]
++
++["storage:staging.kernelci.org"]
++storage_cred = "/home/kernelci/data/ssh/id_rsa_tarball"
+-- 
+2.34.1
+

--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -326,7 +326,7 @@ cmd_api_pipeline() {
     echo "Starting pipeline containers"
     cd checkout/kernelci-pipeline
     REQUIREMENTS=requirements-dev.txt docker-compose $compose_files build
-    SETTINGS=/home/kernelci/config/staging.kernelci.org.conf \
+    SETTINGS=/home/kernelci/config/staging.kernelci.org.toml \
             docker-compose $compose_files up -d
     cd -
 }


### PR DESCRIPTION
Add TOML formatted settings file `staging.kernelci.org.toml` to `kernelci-pipeline`.