### PR TITLE
Add chromeos.staging.kernelci.org script

### DIFF
--- a/chromeos.staging.kernelci.org
+++ b/chromeos.staging.kernelci.org
@@ -1,0 +1,182 @@
+#!/bin/dash
+
+# Periodic job run on chromeos.kernelci.org to merge together all the pending
+# PRs and update the chromeos.kernelci.org branches, trigger a full build/test
+# cycle with a test kernel branch.
+
+set -e
+
+# Trap function for errors
+crash() {
+    local exit_code="$?"
+    # If exit code is 0, then it's not an error
+    [ "$exit_code" -eq 0 ] && exit 0
+    # Generate syslog message
+    logger -t kernelci-deploy "Error in script $0"
+    exit $exit_code
+}
+
+trap 'crash' EXIT
+
+CHROMEOS_SETTINGS="data/chromeos-staging.ini"
+SSH_KEY="keys/id_rsa_staging.kernelci.org"
+TAG_PREFIX='chromeos-staging-'
+MAIN='chromeos'
+
+cmd_pull() {
+    echo "Updating local repository"
+    git pull --ff-only
+}
+
+cmd_jenkins() {
+    echo "Updating Jenkins jobs"
+    ./pending.py \
+        kernelci-jenkins \
+        --settings=${CHROMEOS_SETTINGS} \
+        --ssh-key=${SSH_KEY} \
+        --main=${MAIN} \
+        --tag-prefix=${TAG_PREFIX} \
+        --push
+}
+
+cmd_core() {
+    echo "Updating kernelci-core"
+    ./pending.py \
+        kernelci-core \
+        --settings=${CHROMEOS_SETTINGS} \
+        --ssh-key=${SSH_KEY} \
+        --main=${MAIN} \
+        --tag-prefix=${TAG_PREFIX} \
+        --push
+}
+
+cmd_test_definitions() {
+    echo "Updating test-definitions"
+    ./pending.py \
+        test-definitions \
+        --settings=${CHROMEOS_SETTINGS} \
+        --ssh-key=${SSH_KEY} \
+        --main=${MAIN} \
+        --tag-prefix=${TAG_PREFIX} \
+        --push
+}
+
+cmd_backend() {
+    echo "Updating kernelci-backend"
+    ./pending.py \
+        kernelci-backend \
+        --settings=${CHROMEOS_SETTINGS} \
+        --ssh-key=${SSH_KEY} \
+        --main=${MAIN} \
+        --tag-prefix=${TAG_PREFIX} \
+        --push
+
+    ./ansible \
+        kernelci-backend \
+        api.chromeos.staging.kernelci.org \
+        chromeos.staging.kernelci.org \
+        chromeos.staging.kernelci.org \
+        $PWD/keys/id_rsa_staging.kernelci.org
+}
+
+cmd_frontend() {
+    echo "Updating kernelci-frontend"
+    ./pending.py \
+        kernelci-frontend \
+        --settings=${CHROMEOS_SETTINGS} \
+        --ssh-key=${SSH_KEY} \
+        --main=${MAIN} \
+        --tag-prefix=${TAG_PREFIX} \
+        --push
+
+    ./ansible \
+        kernelci-frontend \
+        chromeos.staging.kernelci.org \
+        chromeos.staging.kernelci.org \
+        chromeos.staging.kernelci.org \
+        $PWD/keys/id_rsa_staging.kernelci.org
+}
+
+cmd_docker() {
+    echo "Updating Docker images"
+    # Build the images with kci_docker
+    cd checkout/kernelci-core
+    core_rev=$(git show --pretty=format:%H -s origin/chromeos.staging.kernelci.org)
+    rev_arg="--build-arg core_rev=$core_rev"
+    px_arg='--prefix=kernelci/staging-cros-'
+    args="build --push $px_arg $rev_arg"
+
+    # KernelCI tools
+    ./kci docker $args kernelci
+    ./kci docker $args k8s kernelci $rev_arg
+
+    # Compiler toolchains
+    for clang in clang-14; do
+	  ./kci docker $args $clang kselftest kernelci $rev_arg
+
+	  for arch in arm arm64 x86; do
+	    ./kci docker $args $clang kselftest kernelci $rev_arg --arch $arch
+	  done
+    done
+    for arch in arm arm64 x86; do
+	./kci docker $args gcc-10 kselftest kernelci --arch $arch $rev_arg
+    done
+
+    px_arg='--prefix=kernelci/staging-'
+    args="build --push $px_arg $rev_arg"
+    # ChromeOS related images
+    # cros-sdk used to create ChromiumOS rootfs, so it needs kernelci-core
+    # also we dont need cros- prefix as with compilers
+    ./kci docker $args cros-sdk kernelci
+    for imgname in cros-baseline cros-qemu-modules cros-tast; do
+	./kci docker $args $rev_arg $imgname
+    done
+    cd -
+}
+
+cmd_kernel() {
+    echo "Pushing chromeos-staging kernel test branch"
+    ./kernel.py \
+        --push \
+        --ssh-key=keys/id_rsa_staging.kernelci.org \
+        --from-url=https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git \
+        --from-branch=linux-6.1.y \
+        --branch=chromeos-staging \
+        --tag-prefix=chromeos-staging
+
+}
+
+cmd_monitor() {
+    echo "Triggering Jenkins kernel-tree-monitor job"
+    python3 \
+        job.py \
+        --json=data/chromeos-staging-monitor.json \
+        trigger \
+        chromeos-staging/kernel-tree-monitor
+}
+
+cmd_all() {
+    tree="$1"
+
+    cmd_pull
+    cmd_jenkins
+    cmd_core
+    cmd_test_definitions
+    # cmd_backend
+    # cmd_frontend
+    cmd_kernel
+    cmd_docker
+    cmd_monitor
+}
+
+cmd="${1}"
+
+if [ -n "$cmd" ]; then
+    shift 1
+else
+    cmd="all"
+fi
+
+"cmd_"$cmd $@
+
+exit 0

--- a/data/chromeos-staging-monitor.json
+++ b/data/chromeos-staging-monitor.json
@@ -1,0 +1,3 @@
+{
+    "CONFIG_LIST": "kernelci_chromeos-staging"
+}

--- a/data/chromeos-staging.ini
+++ b/data/chromeos-staging.ini
@@ -1,0 +1,34 @@
+[DEFAULT]
+branch: chromeos.staging.kernelci.org
+namespace: kernelci
+users:
+    10ne1
+    alexandrasp
+    crazoes
+    gctucker
+    hardboprobot
+    hiwang123
+    kernelci
+    krisman
+    mgalka
+    nfraprado
+    nuclearcat
+    padovan
+    ribalda
+    JenySadadia
+
+[bootrr]
+
+[buildroot]
+
+[kernelci-core]
+
+[kernelci-backend]
+
+[kernelci-frontend]
+
+[kernelci-jenkins]
+
+[kernelci-project]
+
+[test-definitions]

--- a/patches/kernelci-backend/chromeos.staging.kernelci.org/0001-CHROMEOS-update-DB_NAME-and-socket-path.patch
+++ b/patches/kernelci-backend/chromeos.staging.kernelci.org/0001-CHROMEOS-update-DB_NAME-and-socket-path.patch
@@ -1,0 +1,42 @@
+From b418b745b6f96295c68a0ec863632619c90282f9 Mon Sep 17 00:00:00 2001
+From: Michal Galka <michal.galka@collabora.com>
+Date: Thu, 25 May 2023 19:43:27 +0200
+Subject: [PATCH 1/3] CHROMEOS update DB_NAME and socket path
+
+Update database name and socket to match ones for chromeos instance
+
+Signed-off-by: Michal Galka <michal.galka@collabora.com>
+---
+ app/models/__init__.py | 2 +-
+ app/server.py          | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/app/models/__init__.py b/app/models/__init__.py
+index 5ac2c9c..f1e46b4 100644
+--- a/app/models/__init__.py
++++ b/app/models/__init__.py
+@@ -27,7 +27,7 @@
+ # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ 
+ # The default mongodb database name.
+-DB_NAME = "kernel-ci"
++DB_NAME = "chromeos-kernel-ci"
+ 
+ DEFAULT_SCHEMA_VERSION = "1.0"
+ 
+diff --git a/app/server.py b/app/server.py
+index 7faff9d..d159269 100755
+--- a/app/server.py
++++ b/app/server.py
+@@ -171,7 +171,7 @@ if __name__ == "__main__":
+ 
+         server = tornado.httpserver.HTTPServer(application, **HTTP_SETTINGS)
+         unix_socket = tornado.netutil.bind_unix_socket(
+-            "/tmp/kernelci-backend.socket")
++            "/tmp/chromeos-kernelci-backend.socket")
+         server.add_socket(unix_socket)
+     else:
+         KernelCiBackend().listen(topt.options.port, **HTTP_SETTINGS)
+-- 
+2.25.1
+

--- a/patches/kernelci-backend/chromeos.staging.kernelci.org/0002-CHROMEOS-Update-configuration-paths-for-chromeos.sta.patch
+++ b/patches/kernelci-backend/chromeos.staging.kernelci.org/0002-CHROMEOS-Update-configuration-paths-for-chromeos.sta.patch
@@ -1,0 +1,46 @@
+From d44f44d8d2fa5f7acd353b701b7b9c53ef2f93a3 Mon Sep 17 00:00:00 2001
+From: Michal Galka <michal.galka@collabora.com>
+Date: Thu, 25 May 2023 19:51:06 +0200
+Subject: [PATCH 2/3] CHROMEOS Update configuration paths for
+ chromeos.staging.kernelci.org
+
+Update default configuration paths to point to
+chromeos.staging.kernelci.org instance configs
+
+Signed-off-by: Michal Galka <michal.galka@collabora.com>
+---
+ app/server.py           | 3 ++-
+ app/taskqueue/celery.py | 3 ++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/app/server.py b/app/server.py
+index d159269..5d9f2e2 100755
+--- a/app/server.py
++++ b/app/server.py
+@@ -37,7 +37,8 @@ import utils.database.redisdb as redisdb
+ import utils.db
+ 
+ 
+-DEFAULT_CONFIG_FILE = "/etc/kernelci/kernelci-backend.cfg"
++DEFAULT_CONFIG_FILE = "/etc/kernelci/api.chromeos.staging.kernelci.org/" \
++                      "kernelci-backend.cfg"
+ 
+ topt.define(
+     "master_key", default=str(uuid.uuid4()), type=str, help="The master key")
+diff --git a/app/taskqueue/celery.py b/app/taskqueue/celery.py
+index f2c694e..57da9f5 100644
+--- a/app/taskqueue/celery.py
++++ b/app/taskqueue/celery.py
+@@ -35,7 +35,8 @@ import taskqueue.celeryconfig as celeryconfig
+ import taskqueue.serializer as serializer
+ 
+ 
+-CELERY_CONFIG_FILE = "/etc/kernelci/kernelci-celery.cfg"
++CELERY_CONFIG_FILE = "/etc/kernelci/api.chromeos.staging.kernelci.org/" \
++                     "kernelci-celery.cfg"
+ TASKS_LIST = [
+     "taskqueue.tasks.bisect",
+     "taskqueue.tasks.build",
+-- 
+2.25.1
+

--- a/patches/kernelci-backend/chromeos.staging.kernelci.org/0003-CHROMEOS-Update-BASE_PATH-for-storage.chromeos.stagi.patch
+++ b/patches/kernelci-backend/chromeos.staging.kernelci.org/0003-CHROMEOS-Update-BASE_PATH-for-storage.chromeos.stagi.patch
@@ -1,0 +1,30 @@
+From 0e740c6c37cbbfdc41b276ce11ecafda7833e404 Mon Sep 17 00:00:00 2001
+From: Michal Galka <michal.galka@collabora.com>
+Date: Thu, 25 May 2023 20:02:09 +0200
+Subject: [PATCH 3/3] CHROMEOS Update BASE_PATH for
+ storage.chromeos.staging.kernelci.org
+
+Update the BASE_PATH to point to the location of
+storage.chromeos.staging.kernelci.org
+
+Signed-off-by: Michal Galka <michal.galka@collabora.com>
+---
+ app/utils/__init__.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/app/utils/__init__.py b/app/utils/__init__.py
+index 457ec84..fa2e66b 100644
+--- a/app/utils/__init__.py
++++ b/app/utils/__init__.py
+@@ -29,7 +29,7 @@ import re
+ import models
+ import utils.log
+ 
+-BASE_PATH = "/var/www/images/kernel-ci"
++BASE_PATH = "/data/storage.chromeos.staging.kernelci.org"
+ LOG = utils.log.get_log()
+ 
+ # Build log file names.
+-- 
+2.25.1
+

--- a/patches/kernelci-core/chromeos.staging.kernelci.org/0001-CHROMEOS-config-core-Add-build-configs-chromeos-stag.patch
+++ b/patches/kernelci-core/chromeos.staging.kernelci.org/0001-CHROMEOS-config-core-Add-build-configs-chromeos-stag.patch
@@ -1,0 +1,28 @@
+From 12fb4510124b88fc09112c17e388213c77aaed6a Mon Sep 17 00:00:00 2001
+From: Michal Galka <michal.galka@collabora.com>
+Date: Fri, 26 May 2023 07:57:53 +0200
+Subject: [PATCH] CHROMEOS config/core: Add build-configs-chromeos-staging.yaml
+
+Add build configs for chromeos.staging.kernelci.org
+
+Signed-off-by: Michal Galka <michal.galka@collabora.com>
+---
+ config/core/build-configs-chromeos-staging.yaml | 6 ++++++
+ 1 file changed, 6 insertions(+)
+ create mode 100644 config/core/build-configs-chromeos-staging.yaml
+
+diff --git a/config/core/build-configs-chromeos-staging.yaml b/config/core/build-configs-chromeos-staging.yaml
+new file mode 100644
+index 000000000..06960cdf7
+--- /dev/null
++++ b/config/core/build-configs-chromeos-staging.yaml
+@@ -0,0 +1,6 @@
++# build configs for chromeos.staging.kernelci.org instance
++
++  kernelci_chromeos-staging:
++    tree: kernelci
++    branch: 'chromeos-staging'
++    variants: *chromeos_6_1_variants
+-- 
+2.25.1
+

--- a/patches/kernelci-frontend/chromeos.staging.kernelci.org/0001-CHROMEOS-Set-defaults-for-chromeos.staging.kernelci..patch
+++ b/patches/kernelci-frontend/chromeos.staging.kernelci.org/0001-CHROMEOS-Set-defaults-for-chromeos.staging.kernelci..patch
@@ -1,0 +1,43 @@
+From 0d3055c2767f1caa0d8319b771a784671adb797f Mon Sep 17 00:00:00 2001
+From: Michal Galka <michal.galka@collabora.com>
+Date: Thu, 25 May 2023 21:16:39 +0200
+Subject: [PATCH 1/2] CHROMEOS Set defaults for chromeos.staging.kernelci.org
+
+Signed-off-by: Michal Galka <michal.galka@collabora.com>
+---
+ app/dashboard/__init__.py         | 3 ++-
+ app/dashboard/default_settings.py | 4 ++--
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/app/dashboard/__init__.py b/app/dashboard/__init__.py
+index 671a8aaa..ab4c7922 100644
+--- a/app/dashboard/__init__.py
++++ b/app/dashboard/__init__.py
+@@ -51,7 +51,8 @@ __versionfull__ = __version__
+ 
+ CSRF_TOKEN_H = "X-Csrftoken"
+ 
+-DEFAULT_CONFIG_FILE = "/etc/kernelci/kernelci-frontend.cfg"
++DEFAULT_CONFIG_FILE = "/etc/kernelci/chromeos.staging.kernelci.org/" \
++                      "kernelci-frontend.cfg"
+ # Name of the environment variable that will be lookep up for app
+ # configuration parameters.
+ APP_ENVVAR = "FLASK_SETTINGS"
+diff --git a/app/dashboard/default_settings.py b/app/dashboard/default_settings.py
+index 336ceca6..74019ea2 100644
+--- a/app/dashboard/default_settings.py
++++ b/app/dashboard/default_settings.py
+@@ -22,8 +22,8 @@
+ # along with this library; if not, write to the Free Software Foundation, Inc.,
+ # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ 
+-LOGGER_NAME = "kernelci-frontend"
+-SESSION_COOKIE_NAME = "kernelci.org"
++LOGGER_NAME = "chromeos-kernelci-frontend"
++SESSION_COOKIE_NAME = "chromeos.staging.kernelci.org"
+ 
+ # Following keys should be defined in an external file and passed as an
+ # environment variable called FLASK_SETTINGS, or in /etc/kernelci in a file
+-- 
+2.25.1
+

--- a/patches/kernelci-frontend/chromeos.staging.kernelci.org/0002-CHROMEOS-Update-info-on-chromeos.staging.kernelci.or.patch
+++ b/patches/kernelci-frontend/chromeos.staging.kernelci.org/0002-CHROMEOS-Update-info-on-chromeos.staging.kernelci.or.patch
@@ -1,0 +1,65 @@
+From 36146a125114221319793fa65444b4d8a6b33e27 Mon Sep 17 00:00:00 2001
+From: Michal Galka <michal.galka@collabora.com>
+Date: Thu, 25 May 2023 21:22:30 +0200
+Subject: [PATCH 2/2] CHROMEOS Update info on chromeos.staging.kernelci.org
+
+Signed-off-by: Michal Galka <michal.galka@collabora.com>
+---
+ app/dashboard/templates/index.html | 34 ++++++++++++++++++++++--------
+ 1 file changed, 25 insertions(+), 9 deletions(-)
+
+diff --git a/app/dashboard/templates/index.html b/app/dashboard/templates/index.html
+index 192719f4..4350c9e5 100644
+--- a/app/dashboard/templates/index.html
++++ b/app/dashboard/templates/index.html
+@@ -43,22 +43,38 @@
+ <div class="row">
+     <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9">
+         <div class="pull-center" style="margin-top: 1em;">
+-            <h3>KernelCI Dashboard</h3>
++            <h3>Staging Chrome OS KernelCI Dashboard</h3>
+         </div>
+         <div class="welcome-text">
+           <p>
+-            Welcome to the KernelCI web dashboard for the upstream Linux
+-            kernel.
++            Welcome to the staging Chrome OS KernelCI web dashboard.  This is the
++            development instance of <a href="https://chromeos.kernelci.org"
++            target="_blank">linux.kernelci.org</a> where changes are being
++            integrated together and verified.
+           </p>
+           <p>
+-            You'll find here all the results for kernel builds and tests run
+-            natively by KernelCI on mainline, linux-next, stable and a variety
+-            of maintainer branches.
++            Kernel revisions on this instance are for the most part created
++            artificially in order to generate jobs in a controlled fashion.
++            All the open pull requests from the following GitHub projects are
++            merged together on staging branches (chromeos.staging.kernelci.org)and deployed here automatically
++            every 8 hours:
++            <ul>
++              <li><a href="https://github.com/kernelci/kernelci-core" target="_blank"><span style="font-family: mono">kernelci-core</span></a></li>
++              <li><a href="https://github.com/kernelci/kernelci-frontend" target="_blank"><span style="font-family: mono">kernelci-frontend</span></a></li>
++              <li><a href="https://github.com/kernelci/kernelci-backend" target="_blank"><span style="font-family: mono">kernelci-backend</span></a></li>
++              <li><a href="https://github.com/kernelci/kernelci-jenkins" target="_blank"><span style="font-family: mono">kernelci-jenkins</span></a></li>
++              <li><a href="https://github.com/kernelci/test-definitions" target="_blank"><span style="font-family: mono">test-definitions</span></a></li>
++            </ul>
++          </p>
++          <p>
++            A staging instance of
++            the <a href="https://chromeos.kernelci.org">chromeos.kernelci.org</a>
+           </p>
+           <p>
+-            To find out more about the project, see
+-            the main <a href="https://kernelci.org/" title="kernelci.org home
+-            page">kernelci.org</a> website.
++            See
++            the <a href="https://kernelci.org/docs/workflow/staging/">staging
++            documentation</a> to learn more about how this works and how to
++            take part in KernelCI development.
+           </p>
+         </div>
+     </div>
+-- 
+2.25.1
+


### PR DESCRIPTION
Depends on #85 

chromeos.staging.kernelci.org script works in a similar way to other *.kernelci.org scripts. It implements commands to update the chromeos.staging.kernelci.org instance of KernelCI.