### PR TITLE
kci-scheduler: Add scheduler tool to deploy script

### DIFF
--- a/scheduler/install-scheduler.sh
+++ b/scheduler/install-scheduler.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+# This script install KernelCI deploy systemd services and timers
+
+# Check if running as root
+UID=$(id -u)
+if [ "$UID" -ne 0 ]; then
+    echo "Please run this command as root"
+    exit 1
+fi
+
+# cd to script directory
+cd "$(dirname "$0")"
+
+# Copy systemd services and timers
+cp -v *.service /etc/systemd/system/
+cp -v *.timer /etc/systemd/system/
+
+# Reload systemd
+systemctl daemon-reload
+
+# Enable and start services and timers
+ls -1 *.service | xargs -I {} systemctl enable {}.service
+ls -1 *.timer | xargs -I {} systemctl enable {}.timer
+

--- a/scheduler/kci-scheduler-rootfs.service
+++ b/scheduler/kci-scheduler-rootfs.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=KernelCI rootfs builds
+# Might flood a lot of emails, so only enable this if you want to
+#OnFailure=sysadmins-email@domain
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/kernelci/kernelci-deploy/
+ExecStart=/home/kernelci/kernelci-deploy/kernelci.org rootfs
+User=kernelci

--- a/scheduler/kci-scheduler-rootfs.timer
+++ b/scheduler/kci-scheduler-rootfs.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run KernelCI rootfs builds at Friday 9:00 UTC
+
+[Timer]
+Unit=kernelci-scheduler-rootfs.service
+OnCalendar=Fri *-*-* 09:00:00 UTC
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Instead of making simple timer, i decided to make future-proof script that can be used to schedule simple services related to deploy procedures.
For now it will just schedule rootfs builds at friday morning.
Next step might be this scheduler will track if pull request got merged, and for example if it is monday - run docker images build or something like that.