### PR TITLE
Update ChromeOS clang to version 17

### DIFF
--- a/chromeos.kernelci.org
+++ b/chromeos.kernelci.org
@@ -111,7 +111,7 @@ cmd_docker() {
     ./kci docker $args k8s kernelci $rev_arg
 
     # Compiler toolchains
-    for clang in clang-14; do
+    for clang in clang-17; do
 	  ./kci docker $args $clang kselftest kernelci $rev_arg
 
 	  for arch in arm arm64 x86; do


### PR DESCRIPTION
As ChromeOS actually use "bleeding edge" clang, we need to keep up with clang versions for it.