### PR TITLE
staging.kernelci.org: Update rust to 1.71

### DIFF
--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -232,8 +232,8 @@ cmd_docker() {
     ./kci docker $args gcc-10 kernelci --arch sparc
     # only x86 is useful for KUnit (for now)
     ./kci docker $args gcc-10 kunit kernelci --arch x86
-    # rustc-1.70 for linux-next
-    ./kci docker $args rustc-1.70 kselftest kernelci --arch x86
+    # rustc-1.71 for linux-next
+    ./kci docker $args rustc-1.71 kselftest kernelci --arch x86
 
     # rootfs
     ./kci docker $args buildroot kernelci


### PR DESCRIPTION
As rust updated in main tree, it was forgotted(by me) to make test change done here as permanent. Fixing that.