### PR TITLE
staging.kernelci.org: Update patches for jobs.groovy

### DIFF
--- a/patches/kernelci-jenkins/staging.kernelci.org/0001-STAGING-only-send-emails-for-kernelci-tree.patch
+++ b/patches/kernelci-jenkins/staging.kernelci.org/0001-STAGING-only-send-emails-for-kernelci-tree.patch
@@ -1,4 +1,4 @@
-From aa460a815a007e4f7d4d8503198673cb1b32d814 Mon Sep 17 00:00:00 2001
+From 2ef91830a412842514cb10d38c79711d5085792e Mon Sep 17 00:00:00 2001
 From: "kernelci.org bot" <bot@kernelci.org>
 Date: Thu, 30 Jan 2020 14:33:44 +0000
 Subject: [PATCH 1/4] STAGING only send emails for kernelci tree
@@ -8,7 +8,7 @@ Subject: [PATCH 1/4] STAGING only send emails for kernelci tree
  1 file changed, 5 insertions(+)
 
 diff --git a/scripts/kernel-arch-complete.sh b/scripts/kernel-arch-complete.sh
-index 3fc512c..2bcab7d 100755
+index 9d7bbda..7732797 100755
 --- a/scripts/kernel-arch-complete.sh
 +++ b/scripts/kernel-arch-complete.sh
 @@ -35,6 +35,11 @@ fi

--- a/patches/kernelci-jenkins/staging.kernelci.org/0002-STAGING-add-docker-compose-volume.patch
+++ b/patches/kernelci-jenkins/staging.kernelci.org/0002-STAGING-add-docker-compose-volume.patch
@@ -1,4 +1,4 @@
-From 1e8b455e39b077b75c74880b3ab213966e558685 Mon Sep 17 00:00:00 2001
+From 26731ddd33bf69222eec1b08664be4fc28cb41e8 Mon Sep 17 00:00:00 2001
 From: "kernelci.org bot" <bot@kernelci.org>
 Date: Tue, 4 May 2021 11:57:29 +0100
 Subject: [PATCH 2/4] STAGING add docker-compose volume

--- a/patches/kernelci-jenkins/staging.kernelci.org/0003-STAGING-bisect.jpl-add-staging-in-tags-and-email.patch
+++ b/patches/kernelci-jenkins/staging.kernelci.org/0003-STAGING-bisect.jpl-add-staging-in-tags-and-email.patch
@@ -1,4 +1,4 @@
-From c96c1d9c65dc2413e6794f964bd60b529f57adf1 Mon Sep 17 00:00:00 2001
+From 87c1bec8a87848f169aab699d664590498f985dc Mon Sep 17 00:00:00 2001
 From: "kernelci.org bot" <bot@kernelci.org>
 Date: Tue, 7 Jul 2020 21:56:00 +0100
 Subject: [PATCH 3/4] STAGING bisect.jpl: add -staging in tags and email
@@ -8,7 +8,7 @@ Subject: [PATCH 3/4] STAGING bisect.jpl: add -staging in tags and email
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/jobs/bisect.jpl b/jobs/bisect.jpl
-index d67ce74..91522a0 100644
+index e2d8c17..664fca2 100644
 --- a/jobs/bisect.jpl
 +++ b/jobs/bisect.jpl
 @@ -121,7 +121,7 @@ def createTag(kdir, iteration) {

--- a/patches/kernelci-jenkins/staging.kernelci.org/0004-STAGING-jobs.groovy-add-chromeos-jobs.patch
+++ b/patches/kernelci-jenkins/staging.kernelci.org/0004-STAGING-jobs.groovy-add-chromeos-jobs.patch
@@ -1,20 +1,21 @@
-From a479815e04bd0080312a31990e96fbe74b7a7783 Mon Sep 17 00:00:00 2001
+From 1e44b255ac0d6d8e5f29ad542fdebdfde9a89491 Mon Sep 17 00:00:00 2001
 From: Guillaume Tucker <guillaume.tucker@collabora.com>
 Date: Wed, 2 Mar 2022 20:25:29 +0000
 Subject: [PATCH 4/4] STAGING jobs.groovy: add chromeos jobs
 
 ---
- jobs.groovy | 81 +++++++++++++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 81 insertions(+)
+ jobs.groovy | 82 +++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 82 insertions(+)
 
 diff --git a/jobs.groovy b/jobs.groovy
-index b18830d..943431d 100644
+index 09f395c..19a5c97 100644
 --- a/jobs.groovy
 +++ b/jobs.groovy
-@@ -334,3 +334,84 @@ pipelineJob('lava-bisection') {
+@@ -335,3 +335,85 @@ pipelineJob('lava-bisection') {
      stringParam('TREES_WHITELIST', KCI_BISECTION_TREES_WHITELIST, 'If defined, jobs will abort if the KERNEL_TREE is not on that list.')
    }
- }
+ } */
++
 +
 +/* Chrome OS jobs */
 +


### PR DESCRIPTION
As we disabled bisections, we have to update patch for staging which depends on this part of jobs.groovy.