### PR TITLE
kernelci.org: update rust to 1.73

### DIFF
--- a/kernelci.org
+++ b/kernelci.org
@@ -239,7 +239,7 @@ cmd_docker() {
     # only x86 is useful for KUnit (for now)
     ./kci docker $args gcc-10 kunit kernelci --arch x86
     # additional images for Rust
-    for rustc in rustc-1.72; do
+    for rustc in rustc-1.73; do
         ./kci docker $args $rustc kselftest kernelci
         for arch in x86; do
             ./kci docker $args $rustc kselftest kernelci --arch $arch


### PR DESCRIPTION
Update rust version in production deploy script to 1.73