### PR TITLE
staging.kernelci.org: Add absolute path to slack script

### DIFF
--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -7,13 +7,16 @@
 set -e
 
 # Trap function for errors
+ABSPATH=$(readlink -f "$0")
+ABSDIR=$(dirname "$ABSPATH")
+
 crash() {
     local exit_code="$?"
     # If exit code is 0, then it's not an error
     [ "$exit_code" -eq 0 ] && exit 0
     # Generate syslog message
     logger -t kernelci-deploy "Error in script $0"
-    tools/kci-slackbot.py --message "Staging FAILED!!!"
+    ${ABSDIR}/tools/kci-slackbot.py --message "Staging FAILED!!!"
     exit $exit_code
 }
 


### PR DESCRIPTION
As failure might happen at any directory - we need to use absolute path to slack script.