### PR TITLE
Backport patches for VP9 decoding on trogdor

### DIFF
--- a/patches/linux/linux-6.1.y-arm64-chromeos/0049-media-venus-add-firmware-version-based-check.patch
+++ b/patches/linux/linux-6.1.y-arm64-chromeos/0049-media-venus-add-firmware-version-based-check.patch
@@ -1,0 +1,120 @@
+From 737a899e6ff3ce372eef1f7744a28de1893ecda3 Mon Sep 17 00:00:00 2001
+From: Dikshita Agarwal <quic_dikshita@quicinc.com>
+Date: Mon, 22 May 2023 07:02:50 +0100
+Subject: [PATCH 1/2] media: venus: add firmware version based check
+
+Add firmware version based checks to enable/disable
+features for different SOCs.
+
+Tested-by: Nathan Hebert <nhebert@chromium.org>
+Signed-off-by: Vikash Garodia <quic_vgarodia@quicinc.com>
+Signed-off-by: Viswanath Boma <quic_vboma@quicinc.com>
+Signed-off-by: Dikshita Agarwal <quic_dikshita@quicinc.com>
+Signed-off-by: Stanimir Varbanov <stanimir.k.varbanov@gmail.com>
+Signed-off-by: Mauro Carvalho Chehab <mchehab@kernel.org>
+---
+ drivers/media/platform/qcom/venus/core.h     | 20 +++++++++++++
+ drivers/media/platform/qcom/venus/hfi_msgs.c | 30 ++++++++++++++++++--
+ 2 files changed, 47 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/media/platform/qcom/venus/core.h b/drivers/media/platform/qcom/venus/core.h
+index 32551c2602a9..2f2176f3ebf5 100644
+--- a/drivers/media/platform/qcom/venus/core.h
++++ b/drivers/media/platform/qcom/venus/core.h
+@@ -202,6 +202,11 @@ struct venus_core {
+ 	unsigned int core0_usage_count;
+ 	unsigned int core1_usage_count;
+ 	struct dentry *root;
++	struct venus_img_version {
++		u32 major;
++		u32 minor;
++		u32 rev;
++	} venus_ver;
+ };
+ 
+ struct vdec_controls {
+@@ -500,4 +505,19 @@ venus_caps_by_codec(struct venus_core *core, u32 codec, u32 domain)
+ 	return NULL;
+ }
+ 
++static inline bool
++is_fw_rev_or_newer(struct venus_core *core, u32 vmajor, u32 vminor, u32 vrev)
++{
++	return ((core)->venus_ver.major == vmajor &&
++		(core)->venus_ver.minor == vminor &&
++		(core)->venus_ver.rev >= vrev);
++}
++
++static inline bool
++is_fw_rev_or_older(struct venus_core *core, u32 vmajor, u32 vminor, u32 vrev)
++{
++	return ((core)->venus_ver.major == vmajor &&
++		(core)->venus_ver.minor == vminor &&
++		(core)->venus_ver.rev <= vrev);
++}
+ #endif
+diff --git a/drivers/media/platform/qcom/venus/hfi_msgs.c b/drivers/media/platform/qcom/venus/hfi_msgs.c
+index df96db3761a7..65c8fb34cdd6 100644
+--- a/drivers/media/platform/qcom/venus/hfi_msgs.c
++++ b/drivers/media/platform/qcom/venus/hfi_msgs.c
+@@ -248,13 +248,15 @@ static void hfi_sys_init_done(struct venus_core *core, struct venus_inst *inst,
+ }
+ 
+ static void
+-sys_get_prop_image_version(struct device *dev,
++sys_get_prop_image_version(struct venus_core *core,
+ 			   struct hfi_msg_sys_property_info_pkt *pkt)
+ {
++	struct device *dev = core->dev;
+ 	u8 *smem_tbl_ptr;
+ 	u8 *img_ver;
+ 	int req_bytes;
+ 	size_t smem_blk_sz;
++	int ret;
+ 
+ 	req_bytes = pkt->hdr.size - sizeof(*pkt);
+ 
+@@ -263,8 +265,30 @@ sys_get_prop_image_version(struct device *dev,
+ 		return;
+ 
+ 	img_ver = pkt->data;
++	if (!img_ver)
++		return;
++
++	ret = sscanf(img_ver, "14:video-firmware.%u.%u-%u",
++		     &core->venus_ver.major, &core->venus_ver.minor, &core->venus_ver.rev);
++	if (ret)
++		goto done;
++
++	ret = sscanf(img_ver, "14:VIDEO.VPU.%u.%u-%u",
++		     &core->venus_ver.major, &core->venus_ver.minor, &core->venus_ver.rev);
++	if (ret)
++		goto done;
++
++	ret = sscanf(img_ver, "14:VIDEO.VE.%u.%u-%u",
++		     &core->venus_ver.major, &core->venus_ver.minor, &core->venus_ver.rev);
++	if (ret)
++		goto done;
+ 
+-	dev_dbg(dev, VDBGL "F/W version: %s\n", img_ver);
++	dev_err(dev, VDBGL "error reading F/W version\n");
++	return;
++
++done:
++	dev_dbg(dev, VDBGL "F/W version: %s, major %u, minor %u, revision %u\n",
++		img_ver, core->venus_ver.major, core->venus_ver.minor, core->venus_ver.rev);
+ 
+ 	smem_tbl_ptr = qcom_smem_get(QCOM_SMEM_HOST_ANY,
+ 		SMEM_IMG_VER_TBL, &smem_blk_sz);
+@@ -286,7 +310,7 @@ static void hfi_sys_property_info(struct venus_core *core,
+ 
+ 	switch (pkt->property) {
+ 	case HFI_PROPERTY_SYS_IMAGE_VERSION:
+-		sys_get_prop_image_version(dev, pkt);
++		sys_get_prop_image_version(core, pkt);
+ 		break;
+ 	default:
+ 		dev_dbg(dev, VDBGL "unknown property data\n");
+-- 
+2.30.2
+

--- a/patches/linux/linux-6.1.y-arm64-chromeos/0050-media-venus-enable-sufficient-sequence-change-suppor.patch
+++ b/patches/linux/linux-6.1.y-arm64-chromeos/0050-media-venus-enable-sufficient-sequence-change-suppor.patch
@@ -1,0 +1,73 @@
+From d6f2cbd01a6706374223730f295976cf54dabf37 Mon Sep 17 00:00:00 2001
+From: Dikshita Agarwal <quic_dikshita@quicinc.com>
+Date: Mon, 22 May 2023 07:02:51 +0100
+Subject: [PATCH 2/2] media: venus: enable sufficient sequence change support
+ for vp9
+
+VP9 supports resolution change at interframe.
+Currenlty, if sequence change is detected at interframe and
+resources are sufficient, sequence change event is not raised
+by firmware to driver until the next keyframe.
+This change add the HFI to notify the sequence change in this
+case to driver.
+
+Reviewed-by: Konrad Dybcio <konrad.dybcio@linaro.org>
+Tested-by: Nathan Hebert <nhebert@chromium.org>
+Signed-off-by: Vikash Garodia <quic_vgarodia@quicinc.com>
+Signed-off-by: Viswanath Boma <quic_vboma@quicinc.com>
+Signed-off-by: Dikshita Agarwal <quic_dikshita@quicinc.com>
+Signed-off-by: Stanimir Varbanov <stanimir.k.varbanov@gmail.com>
+Signed-off-by: Mauro Carvalho Chehab <mchehab@kernel.org>
+---
+ drivers/media/platform/qcom/venus/hfi_cmds.c   | 1 +
+ drivers/media/platform/qcom/venus/hfi_helper.h | 2 ++
+ drivers/media/platform/qcom/venus/vdec.c       | 8 ++++++++
+ 3 files changed, 11 insertions(+)
+
+diff --git a/drivers/media/platform/qcom/venus/hfi_cmds.c b/drivers/media/platform/qcom/venus/hfi_cmds.c
+index 930b743f225e..e2539b58340f 100644
+--- a/drivers/media/platform/qcom/venus/hfi_cmds.c
++++ b/drivers/media/platform/qcom/venus/hfi_cmds.c
+@@ -521,6 +521,7 @@ static int pkt_session_set_property_1x(struct hfi_session_set_property_pkt *pkt,
+ 		pkt->shdr.hdr.size += sizeof(u32) + sizeof(*en);
+ 		break;
+ 	}
++	case HFI_PROPERTY_PARAM_VDEC_ENABLE_SUFFICIENT_SEQCHANGE_EVENT:
+ 	case HFI_PROPERTY_CONFIG_VDEC_POST_LOOP_DEBLOCKER: {
+ 		struct hfi_enable *in = pdata;
+ 		struct hfi_enable *en = prop_data;
+diff --git a/drivers/media/platform/qcom/venus/hfi_helper.h b/drivers/media/platform/qcom/venus/hfi_helper.h
+index d2d6719a2ba4..2e03b6e172f2 100644
+--- a/drivers/media/platform/qcom/venus/hfi_helper.h
++++ b/drivers/media/platform/qcom/venus/hfi_helper.h
+@@ -469,6 +469,8 @@
+ #define HFI_PROPERTY_PARAM_VDEC_PIXEL_BITDEPTH			0x1003007
+ #define HFI_PROPERTY_PARAM_VDEC_PIC_STRUCT			0x1003009
+ #define HFI_PROPERTY_PARAM_VDEC_COLOUR_SPACE			0x100300a
++#define HFI_PROPERTY_PARAM_VDEC_ENABLE_SUFFICIENT_SEQCHANGE_EVENT \
++								0x100300b
+ 
+ /*
+  * HFI_PROPERTY_CONFIG_VDEC_COMMON_START
+diff --git a/drivers/media/platform/qcom/venus/vdec.c b/drivers/media/platform/qcom/venus/vdec.c
+index 1a52c2ea2da5..c46158ed69ab 100644
+--- a/drivers/media/platform/qcom/venus/vdec.c
++++ b/drivers/media/platform/qcom/venus/vdec.c
+@@ -679,6 +679,14 @@ static int vdec_set_properties(struct venus_inst *inst)
+ 			return ret;
+ 	}
+ 
++	/* Enabling sufficient sequence change support for VP9 */
++	if (is_fw_rev_or_newer(inst->core, 5, 4, 51)) {
++		ptype = HFI_PROPERTY_PARAM_VDEC_ENABLE_SUFFICIENT_SEQCHANGE_EVENT;
++		ret = hfi_session_set_property(inst, ptype, &en);
++		if (ret)
++			return ret;
++	}
++
+ 	ptype = HFI_PROPERTY_PARAM_VDEC_CONCEAL_COLOR;
+ 	conceal = ctr->conceal_color & 0xffff;
+ 	conceal |= ((ctr->conceal_color >> 16) & 0xffff) << 10;
+-- 
+2.30.2
+


### PR DESCRIPTION
Backport patches from 6.6 to fix VP9 decoding on trogdor Chromebooks.