### PR TITLE
patches: linux-6.1.y-arm64-chromeos: fix for 6.1.68+

### DIFF
--- a/patches/linux/linux-6.1.y-arm64-chromeos/0019-arm64-dts-mediatek-mt8183-kukui-Couple-VGPU-and-VSRA.patch
+++ b/patches/linux/linux-6.1.y-arm64-chromeos/0019-arm64-dts-mediatek-mt8183-kukui-Couple-VGPU-and-VSRA.patch
@@ -48,7 +48,7 @@ index b4b86bb1f1a7..6205e0aad6c7 100644
 +
  &pio {
  	aud_pins_default: audiopins {
- 		pins_bus {
+ 		pins-bus {
 -- 
 2.40.0
 

--- a/patches/linux/linux-6.1.y-arm64-chromeos/0022-arm64-dts-mt8183-pumpkin-Couple-VGPU-and-VSRAM_GPU-r.patch
+++ b/patches/linux/linux-6.1.y-arm64-chromeos/0022-arm64-dts-mt8183-pumpkin-Couple-VGPU-and-VSRAM_GPU-r.patch
@@ -41,7 +41,7 @@ index a1d01639df30..c228f04d086b 100644
 +
  &pio {
  	i2c_pins_0: i2c0 {
- 		pins_i2c{
+ 		pins_i2c {
 -- 
 2.40.0
 

--- a/patches/linux/linux-6.1.y-arm64-chromeos/0023-arm64-dts-mediatek-mt8183-evb-Couple-VGPU-and-VSRAM_.patch
+++ b/patches/linux/linux-6.1.y-arm64-chromeos/0023-arm64-dts-mediatek-mt8183-evb-Couple-VGPU-and-VSRAM_.patch
@@ -40,8 +40,8 @@ index 52dc4a50e34d..fd327437e932 100644
 +};
 +
  &pio {
- 	i2c_pins_0: i2c0{
- 		pins_i2c{
+ 	i2c_pins_0: i2c0 {
+ 		pins_i2c {
 -- 
 2.40.0
 


### PR DESCRIPTION
Minor changes in mt8183 dts files caused some of our patches to fail applying starting with 6.1.68. Reflect those changes so we can get 6.1 kernels tested again.