### PR TITLE
staging.kernelci.org: Add pidfile to avoid concurrent runs

### DIFF
--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -17,10 +17,27 @@ crash() {
     # Generate syslog message
     logger -t kernelci-deploy "Error in script $0"
     ${ABSDIR}/tools/kci-slackbot.py --message "Staging FAILED!!!"
+    # remove pidfile
+    rm -f /var/run/staging.kernelci.org.pid
     exit $exit_code
 }
 
 trap 'crash' EXIT
+
+# verify if the script is already running
+if [ -f /var/run/staging.kernelci.org.pid ]; then
+    pid=$(cat /var/run/staging.kernelci.org.pid)
+    if [ -d /proc/$pid ]; then
+        echo "Script already running with pid $pid"
+        exit 1
+    else
+        echo "Removing stale pidfile"
+        rm -f /var/run/staging.kernelci.org.pid
+    fi
+fi
+
+# create pidfile
+echo $$ > /var/run/staging.kernelci.org.pid
 
 cmd_pull() {
     echo "Updating local repository"
@@ -377,4 +394,6 @@ fi
 
 "cmd_"$cmd $@
 
+# remove pidfile
+rm -f /var/run/staging.kernelci.org.pid
 exit 0

--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -64,18 +64,18 @@ cmd_jenkins() {
     git prune
     git remote update origin
     data_diff=$(git diff origin/main)
-    #if [ -n "$data_diff" ]; then
+    if [ -n "$data_diff" ]; then
         git checkout origin/main
         cd "$topdir/checkout/kernelci-jenkins"
         echo "Recreating Jenkins container"
         docker-compose down
         docker-compose up --build -d
         sleep 60  # magic - another way to do this would be to poll something
-    #else
-    #    cd "$topdir/checkout/kernelci-jenkins"
-    #    # ToDo: restart the container but only when there were some changes in
-    #    # kernelci-jenkins to avoid aborting running jobs unnecessarily
-    #fi
+    else
+        cd "$topdir/checkout/kernelci-jenkins"
+        # ToDo: restart the container but only when there were some changes in
+        # kernelci-jenkins to avoid aborting running jobs unnecessarily
+    fi
     cd "$topdir"
 
     echo "Triggering Jenkins seed job"


### PR DESCRIPTION
In some situations it is possible that staging script might get "stuck" and another run might conflict with it. We add basic pidfile to avoid this.