### PR TITLE
patches/kernelci-core: update patch for kci bisection emails

### DIFF
--- a/patches/kernelci-core/staging.kernelci.org/0002-STAGING-ensure-no-public-bisection-email-reports-are.patch
+++ b/patches/kernelci-core/staging.kernelci.org/0002-STAGING-ensure-no-public-bisection-email-reports-are.patch
@@ -1,16 +1,16 @@
-From f6b1031ab7b5a6cb22ea0f6e2596e5279571d4d8 Mon Sep 17 00:00:00 2001
+From 9d1cb0f8889a025e3e7ec5e60a9d14f74c71a391 Mon Sep 17 00:00:00 2001
 From: "kernelci.org bot" <bot@kernelci.org>
-Date: Fri, 3 Jan 2020 16:09:40 +0000
+Date: Thu, 18 Jan 2024 17:42:11 +0530
 Subject: [PATCH 2/6] STAGING ensure no public bisection email reports are sent
 
 ---
- scripts/kci-bisect-push-results | 2 ++
+ kernelci/scripts/kci_bisect_push_results.py | 2 ++
  1 file changed, 2 insertions(+)
 
-diff --git a/scripts/kci-bisect-push-results b/scripts/kci-bisect-push-results
-index 8d2fe39ad..fe2bdc6aa 100755
---- a/scripts/kci-bisect-push-results
-+++ b/scripts/kci-bisect-push-results
+diff --git a/kernelci/scripts/kci_bisect_push_results.py b/kernelci/scripts/kci_bisect_push_results.py
+index d3549d9d..56a51c93 100755
+--- a/kernelci/scripts/kci_bisect_push_results.py
++++ b/kernelci/scripts/kci_bisect_push_results.py
 @@ -225,6 +225,8 @@ def send_report(args, log_file_name, token, api):
          cc = set()
          for r in to:
@@ -21,5 +21,5 @@ index 8d2fe39ad..fe2bdc6aa 100755
      data.update({
          'report_type': 'bisect',
 -- 
-2.39.2
+2.34.1
 


### PR DESCRIPTION
Related to https://github.com/kernelci/kernelci-core/pull/2286

The `kci-bisect-push-results` has been converted to the symlink to `kernelci/scripts/kci_bisect_push_results.py` file as part of adding `pyproject.toml` for `kernelci` python packaging. Update the patch for sending bisection email reports for staging accordingly.