### PR TITLE
Change stable to 6.1 tree

### DIFF
--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -179,7 +179,7 @@ cmd_kernel() {
             ;;
         stable)
             url=https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
-            branch=linux-5.15.y
+            branch=linux-6.1.y
             ;;
         cip)
             url=https://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git


### PR DESCRIPTION
We need newer kernel for arm64 testing on current devices.