### PR TITLE
Rust 1.75 (staging)

### DIFF
--- a/patches/kernelci-core/staging.kernelci.org/0001-STAGING-add-build-configs-staging.yaml.patch
+++ b/patches/kernelci-core/staging.kernelci.org/0001-STAGING-add-build-configs-staging.yaml.patch
@@ -1,4 +1,4 @@
-From a6967ab9aa4d4aacc2882bd10bc4bf9607641518 Mon Sep 17 00:00:00 2001
+From 0be2fc9172511025231f72e510da3d6469699356 Mon Sep 17 00:00:00 2001
 From: Guillaume Tucker <guillaume.tucker@collabora.com>
 Date: Wed, 15 Dec 2021 14:44:58 +0000
 Subject: [PATCH 1/6] STAGING add build-configs-staging.yaml
@@ -10,7 +10,7 @@ Subject: [PATCH 1/6] STAGING add build-configs-staging.yaml
 
 diff --git a/config/core/build-configs-staging.yaml b/config/core/build-configs-staging.yaml
 new file mode 100644
-index 000000000..42854a58d
+index 000000000..5c95bf4c9
 --- /dev/null
 +++ b/config/core/build-configs-staging.yaml
 @@ -0,0 +1,115 @@
@@ -95,8 +95,8 @@ index 000000000..42854a58d
 +    variants:
 +      gcc-10: *staging-gcc-10
 +      clang-17: *staging-clang-17
-+      rustc-1.74:
-+        build_environment: rustc-1.74
++      rustc-1.75:
++        build_environment: rustc-1.75
 +        fragments: [rust]
 +        architectures:
 +          x86_64:

--- a/patches/kernelci-core/staging.kernelci.org/0002-STAGING-ensure-no-public-bisection-email-reports-are.patch
+++ b/patches/kernelci-core/staging.kernelci.org/0002-STAGING-ensure-no-public-bisection-email-reports-are.patch
@@ -1,4 +1,4 @@
-From 9d1cb0f8889a025e3e7ec5e60a9d14f74c71a391 Mon Sep 17 00:00:00 2001
+From b33809c2d0de7164e6916ba358bafb17bd8e90cf Mon Sep 17 00:00:00 2001
 From: "kernelci.org bot" <bot@kernelci.org>
 Date: Thu, 18 Jan 2024 17:42:11 +0530
 Subject: [PATCH 2/6] STAGING ensure no public bisection email reports are sent
@@ -8,7 +8,7 @@ Subject: [PATCH 2/6] STAGING ensure no public bisection email reports are sent
  1 file changed, 2 insertions(+)
 
 diff --git a/kernelci/scripts/kci_bisect_push_results.py b/kernelci/scripts/kci_bisect_push_results.py
-index d3549d9d..56a51c93 100755
+index d3549d9d3..56a51c938 100755
 --- a/kernelci/scripts/kci_bisect_push_results.py
 +++ b/kernelci/scripts/kci_bisect_push_results.py
 @@ -225,6 +225,8 @@ def send_report(args, log_file_name, token, api):
@@ -21,5 +21,5 @@ index d3549d9d..56a51c93 100755
      data.update({
          'report_type': 'bisect',
 -- 
-2.34.1
+2.39.2
 

--- a/patches/kernelci-core/staging.kernelci.org/0003-STAGING-use-kernelci-staging-qemu-Docker-image.patch
+++ b/patches/kernelci-core/staging.kernelci.org/0003-STAGING-use-kernelci-staging-qemu-Docker-image.patch
@@ -1,4 +1,4 @@
-From 04cd33e5cd91dd4511d670167bb6d8fb3dd44ebf Mon Sep 17 00:00:00 2001
+From bb6962ecd766e3f5a6f99e0ea5f11b81e9909bc7 Mon Sep 17 00:00:00 2001
 From: "kernelci.org bot" <bot@kernelci.org>
 Date: Fri, 29 Jan 2021 15:50:42 +0000
 Subject: [PATCH 3/6] STAGING use kernelci/staging-qemu Docker image

--- a/patches/kernelci-core/staging.kernelci.org/0004-STAGING-use-staging.kernelci.org-branch-for-test-def.patch
+++ b/patches/kernelci-core/staging.kernelci.org/0004-STAGING-use-staging.kernelci.org-branch-for-test-def.patch
@@ -1,4 +1,4 @@
-From d3d3126948ef68dcda9a5a748d57a836f8f3d59a Mon Sep 17 00:00:00 2001
+From e2807858aca61ee66750334832d65c9a470d2c28 Mon Sep 17 00:00:00 2001
 From: "kernelci.org bot" <bot@kernelci.org>
 Date: Tue, 15 Sep 2020 10:22:30 +0100
 Subject: [PATCH 4/6] STAGING use staging.kernelci.org branch for test

--- a/patches/kernelci-core/staging.kernelci.org/0005-STAGING-use-staging-branch-for-buildroot-with-reduce.patch
+++ b/patches/kernelci-core/staging.kernelci.org/0005-STAGING-use-staging-branch-for-buildroot-with-reduce.patch
@@ -1,4 +1,4 @@
-From 934df86dfc463fe4e8a426a898eae2292f823d31 Mon Sep 17 00:00:00 2001
+From fd4501f605117d263a83b7cd3b353bedd208be7c Mon Sep 17 00:00:00 2001
 From: "kernelci.org bot" <bot@kernelci.org>
 Date: Tue, 22 Mar 2022 17:38:32 +0000
 Subject: [PATCH 5/6] STAGING use staging branch for buildroot with reduced
@@ -9,10 +9,10 @@ Subject: [PATCH 5/6] STAGING use staging branch for buildroot with reduced
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/config/core/rootfs-configs.yaml b/config/core/rootfs-configs.yaml
-index f5c55986f..c10225213 100644
+index 59cc35fe9..c4ab3f18a 100644
 --- a/config/core/rootfs-configs.yaml
 +++ b/config/core/rootfs-configs.yaml
-@@ -47,7 +47,7 @@ rootfs_configs:
+@@ -63,7 +63,7 @@ rootfs_configs:
    buildroot-baseline:
      rootfs_type: buildroot
      git_url: https://github.com/kernelci/buildroot

--- a/patches/kernelci-core/staging.kernelci.org/0006-STAGING-use-staging-JWT-in-kubernetes-template.patch
+++ b/patches/kernelci-core/staging.kernelci.org/0006-STAGING-use-staging-JWT-in-kubernetes-template.patch
@@ -1,4 +1,4 @@
-From 3b3338ac8d5d8d55528ef98bee71cfddd54de457 Mon Sep 17 00:00:00 2001
+From 1352376e62fd0c26aed2811cd426ac630cb2cf1c Mon Sep 17 00:00:00 2001
 From: "kernelci.org bot" <bot@kernelci.org>
 Date: Fri, 1 Sep 2023 18:46:13 +0000
 Subject: [PATCH 6/6] STAGING use staging JWT in kubernetes template
@@ -8,10 +8,10 @@ Subject: [PATCH 6/6] STAGING use staging JWT in kubernetes template
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/config/runtime/base/kubernetes.jinja2 b/config/runtime/base/kubernetes.jinja2
-index 01d6ab97f..3e8e7686a 100644
+index 47de9d851..6d93ba1c4 100644
 --- a/config/runtime/base/kubernetes.jinja2
 +++ b/config/runtime/base/kubernetes.jinja2
-@@ -80,7 +80,7 @@ spec:
+@@ -65,7 +65,7 @@ spec:
            valueFrom:
              secretKeyRef:
                # FIXME: convert to template parameter

--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -254,8 +254,13 @@ cmd_docker() {
     ./kci docker $args gcc-10 kernelci --arch sparc
     # only x86 is useful for KUnit (for now)
     ./kci docker $args gcc-10 kunit kernelci --arch x86
-    # latest rustc for linux-next and rust-for-linux
-    ./kci docker $args rustc-1.74 kselftest kernelci --arch x86
+    # additional images for Rust
+    for rustc in rustc-1.74 rustc-1.75; do
+        ./kci docker $args $rustc kselftest kernelci
+        for arch in x86; do
+            ./kci docker $args $rustc kselftest kernelci --arch $arch
+        done
+    done
 
     # rootfs
     ./kci docker $args buildroot kernelci


### PR DESCRIPTION
Could a sysadmin please create the `kernelci/staging-rustc-1.75` and `kernelci/rustc-1.75` repositories on Docker hub?

Please note that in the staging patches, as usual, I only change the version, but we would like to keep both the latest and the previous latest -- is it needed that we test both here, or just the latest added? Please see my note at https://github.com/kernelci/kernelci-core/pull/2321.

Upgrade PRs:
  - https://github.com/kernelci/kernelci-core/pull/2321.
  - https://github.com/kernelci/kernelci-deploy/pull/121.
  - https://github.com/kernelci/kernelci-deploy/pull/122.