### PR TITLE
Rust 1.75

### DIFF
--- a/kernelci.org
+++ b/kernelci.org
@@ -239,7 +239,7 @@ cmd_docker() {
     # only x86 is useful for KUnit (for now)
     ./kci docker $args gcc-10 kunit kernelci --arch x86
     # additional images for Rust
-    for rustc in rustc-1.74; do
+    for rustc in rustc-1.74 rustc-1.75; do
         ./kci docker $args $rustc kselftest kernelci
         for arch in x86; do
             ./kci docker $args $rustc kselftest kernelci --arch $arch


### PR DESCRIPTION
This time around, keep `rustc-1.74` around, since we will use both (i.e. the latest and the previous latest).

Needs testing in staging first, please see https://github.com/kernelci/kernelci-deploy/pull/121.

Upgrade PRs:
  - https://github.com/kernelci/kernelci-core/pull/2321.
  - https://github.com/kernelci/kernelci-deploy/pull/121.
  - https://github.com/kernelci/kernelci-deploy/pull/122.