### PR TITLE
data/staging.ini: Allow Daniel Wagner's PRs to run on staging

### DIFF
--- a/data/staging.ini
+++ b/data/staging.ini
@@ -26,6 +26,7 @@ users:
     hardboprobot
     hiwang123
     hthiery
+    igaw
     jayaddison-collabora
     JenySadadia
     jeromebrunet


### PR DESCRIPTION
Daniel is a kernel developer working on real time and looking at testing
for the RT stable kernel, allow his PRs to run on staging.

Signed-off-by: Mark Brown <broonie@kernel.org>
