### PR TITLE
Add pipeline production image

### DIFF
--- a/kernelci.org
+++ b/kernelci.org
@@ -61,6 +61,11 @@ cmd_api() {
     _cmd_repo kernelci-api "$branch"
 }
 
+cmd_pipeline() {
+    branch="${1:-kernelci.org}"
+    _cmd_repo kernelci-pipeline "$branch"
+}
+
 cmd_jenkins() {
     # ToDo
     return 0
@@ -229,10 +234,15 @@ cmd_docker() {
     api_rev=$(git show --pretty=format:%H -s origin/kernelci.org)
     cd -
 
+    # Get Pipeline revision to tag the image
+    cd checkout/kernelci-pipeline
+    pipeline_rev=$(git show --pretty=format:%H -s origin/kernelci.org)
+    cd -
+
     cd checkout/kernelci-core
 
     core_rev=$(git show --pretty=format:%H -s origin/kernelci.org)
-    base_args="build --build-arg core_rev=$core_rev --build-arg api_rev=$api_rev"
+    base_args="build --build-arg core_rev=$core_rev --build-arg api_rev=$api_rev --build-arg pipeline_rev=$pipeline_rev"
     args="$base_args --prefix=kernelci/ --push --no-cache"
 
     # KernelCI tools
@@ -240,6 +250,7 @@ cmd_docker() {
     ./kci docker $args k8s kernelci
 
     ./kci docker $args api --version="$api_rev"
+    ./kci docker $args pipeline --version="$pipeline_rev"
 
     # Compiler toolchains
     for clang in clang-11 clang-12 clang-13 clang-14 clang-15 clang-16 clang-17; do

--- a/kernelci.org
+++ b/kernelci.org
@@ -232,7 +232,7 @@ cmd_docker() {
     cd checkout/kernelci-core
 
     core_rev=$(git show --pretty=format:%H -s origin/kernelci.org)
-    base_args="build --build-arg core_rev=$core_rev"
+    base_args="build --build-arg core_rev=$core_rev --build-arg api_rev=$api_rev"
     args="$base_args --prefix=kernelci/ --push --no-cache"
 
     # KernelCI tools

--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -93,6 +93,11 @@ cmd_api() {
     ./pending.py kernelci-api --push
 }
 
+cmd_pipeline() {
+    echo "Updating kernelci-pipeline"
+    ./pending.py kernelci-pipeline --push
+}
+
 cmd_bootrr() {
     echo "Updating bootrr"
     ./pending.py bootrr --push
@@ -231,12 +236,17 @@ cmd_docker() {
     api_rev=$(git show --pretty=format:%H -s origin/staging.kernelci.org)
     cd -
 
+    # Get Pipeline revision to tag the image
+    cd checkout/kernelci-pipeline
+    pipeline_rev=$(git show --pretty=format:%H -s origin/staging.kernelci.org)
+    cd -
+
     # Build the images with kci docker
     cd checkout/kernelci-core
     git prune
 
     core_rev=$(git show --pretty=format:%H -s origin/staging.kernelci.org)
-    rev_arg="--build-arg core_rev=$core_rev --build-arg api_rev=$api_rev"
+    rev_arg="--build-arg core_rev=$core_rev --build-arg api_rev=$api_rev --build-arg pipeline_rev=$pipeline_rev"
     px_arg='--prefix=kernelci/staging-'
     args="build --push $px_arg $cache_arg $rev_arg"
 
@@ -245,9 +255,12 @@ cmd_docker() {
     ./kci docker $args k8s kernelci
 
     ./kci docker $args api --version="$api_rev"
+    ./kci docker $args pipeline --version="$pipeline_rev"
     # TODO - add this functionality to kci docker
     docker tag kernelci/staging-api:$api_rev kernelci/staging-api:latest
     docker push kernelci/staging-api:latest
+    docker tag kernelci/staging-pipeline:$pipeline_rev kernelci/staging-pipeline:latest
+    docker push kernelci/staging-pipeline:latest
 
     # Compiler toolchains
 
@@ -370,6 +383,7 @@ cmd_all() {
     cmd_jenkins
     cmd_core
     cmd_api
+    cmd_pipeline
     cmd_bootrr
     cmd_buildroot
     cmd_test_definitions


### PR DESCRIPTION
This PR sets up both staging and production image build (including pushing them to registry).

It depends on kernelci/kernelci-core#2354 and on the presence of `kernelci.org` branch in the `kernelci-pipeline` repository.