### PR TITLE
Disable rust builds by default

### DIFF
--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -214,6 +214,7 @@ cmd_docker() {
 
     # Build without cache if flag file doesn't exist or older than x days
     purge_flag_file=".last_docker_purge"
+    rust_flag_file=".build_rust"
     if [ -f "$purge_flag_file" ]; then
         flag_time=$(date -r "$purge_flag_file" +%s)
         week_ago=$(date -d 'now - 7 days' +%s)
@@ -270,11 +271,15 @@ cmd_docker() {
     # only x86 is useful for KUnit (for now)
     ./kci docker $args gcc-10 kunit kernelci --arch x86
     # additional images for Rust
-    for rustc in rustc-1.74 rustc-1.75; do
-        ./kci docker $args $rustc kselftest kernelci
-        for arch in x86; do
-            ./kci docker $args $rustc kselftest kernelci --arch $arch
+    if [ -f "$rust_flag_file" ]; then
+        for rustc in rustc-1.74 rustc-1.75; do
+            ./kci docker $args $rustc kselftest kernelci
+            for arch in x86; do
+                ./kci docker $args $rustc kselftest kernelci --arch $arch
+            done
         done
+        else
+            echo "Rust images not built, please touch .build_rust file to build them"
     done
 
     # rootfs


### PR DESCRIPTION
Rust PR are coming relatively rarely, but rebuilding them on staging takes a lot of time. Let's make it optional, solution is not best how to enable them, but will work for now.