### PR TITLE
Use `kernelci` image with `api` fragment

### DIFF
--- a/kernelci.org
+++ b/kernelci.org
@@ -239,7 +239,7 @@ cmd_docker() {
     ./kci docker $args kernelci
     ./kci docker $args k8s kernelci
 
-    ./kci docker $args api --version="$api_rev"
+    ./kci docker $args kernelci api --version="$api_rev"
 
     # Compiler toolchains
     for clang in clang-11 clang-12 clang-13 clang-14 clang-15 clang-16 clang-17; do

--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -245,10 +245,10 @@ cmd_docker() {
     ./kci docker $args kernelci
     ./kci docker $args k8s kernelci
 
-    ./kci docker $args api --version="$api_rev"
+    ./kci docker $args kernelci api --version="$api_rev"
     # TODO - add this functionality to kci docker
-    docker tag kernelci/staging-api:$api_rev kernelci/staging-api:latest
-    docker push kernelci/staging-api:latest
+    docker tag kernelci/staging-kernelci:api-$api_rev kernelci/staging-kernelci:api
+    docker push kernelci/staging-kernelci:api
 
     # Compiler toolchains
 

--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -349,6 +349,7 @@ cmd_api_pipeline() {
     git prune
     docker-compose down
     echo "Starting API containers"
+    docker-compose build --no-cache
     docker-compose up -d
     cd -
 
@@ -357,7 +358,7 @@ cmd_api_pipeline() {
 
     echo "Starting pipeline containers"
     cd checkout/kernelci-pipeline
-    REQUIREMENTS=requirements-dev.txt docker-compose $compose_files build
+    REQUIREMENTS=requirements-dev.txt docker-compose $compose_files build --no-cache
     SETTINGS=/home/kernelci/config/staging.kernelci.org.secrets.toml \
             docker-compose $compose_files up -d
     cd -


### PR DESCRIPTION
Depends on https://github.com/kernelci/kernelci-core/pull/2495

Due to recent changes in the `api.jinja2` template, `kernelci` docker image has to be built with `api` fragment to run API services. Update `kci docker` command for `api` accordingly in `staging.kernelci.org` and `kernelci.org` scripts.