### PR TITLE
Import kci-easy as a new deployment type

### DIFF
--- a/localinstall/.env-api
+++ b/localinstall/.env-api
@@ -1,0 +1,8 @@
+SECRET_KEY=b6451545d2e4635148d768f07877aade3ad8e7e160d52962badd7587a4b9a150
+#algorithm=
+#access_token_expire_minutes=
+SMTP_HOST=localhost
+SMTP_PORT=25
+EMAIL_SENDER=banana@collabora.com
+EMAIL_PASSWORD=bananapassword
+KERNELCI_API_IMAGE=local/staging-api

--- a/localinstall/1-rebuild_all.sh
+++ b/localinstall/1-rebuild_all.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+. ./main.cfg
+
+# i am groot?
+if [ $(id -u) -ne 0 ]; then
+    SUDO=sudo
+else
+    SUDO=
+fi
+
+function failonerror {
+    if [ $? -ne 0 ]; then
+        echo "Failed"
+        exit 1
+    fi
+}
+
+# if directry kernelci doesn't exist, then we dont have repos cloned
+if [ ! -d kernelci ]; then
+    echo Create kernelci directory, clone repos and checkout branches
+    mkdir kernelci
+    cd kernelci
+    echo Clone core, api and pipeline repos
+
+    echo Clone core repo
+    git clone $KCI_CORE_REPO
+    cd kernelci-core
+    git fetch origin
+    git checkout origin/$KCI_CORE_BRANCH
+    cd ..
+
+    echo Clone api repo
+    git clone $KCI_API_REPO
+    cd kernelci-api
+    git fetch origin
+    git checkout origin/$KCI_API_BRANCH
+    cd ..
+
+    echo Clone pipeline repo
+    git clone $KCI_PIPELINE_REPO
+    cd kernelci-pipeline
+    git fetch origin
+    git checkout origin/$KCI_PIPELINE_BRANCH
+    cd ..
+else
+    cd kernelci
+fi
+
+# if KCI_CACHE set, git clone linux kernel tree and keep as archive
+if [ -n "$KCI_CACHE" ]; then
+    if [ ! -f ../linux.tar ]; then
+        git clone https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git linux
+        tar -cf ../linux.tar linux
+        rm -rf linux
+    fi
+fi
+
+# if KCI_CACHE set, unpack linux kernel tree to 
+# kernelci/kernelci-pipeline/data/src
+if [ -n "$KCI_CACHE" ]; then
+    if [ ! -d kernelci-pipeline/data/src/linux ]; then
+        tar -xf ../linux.tar -C kernelci-pipeline/data/src
+        $SUDO chown -R 1000:1000 kernelci-pipeline/data/src/linux
+    fi
+fi
+
+# build docker images
+# purge docker build cache with confirmation
+echo "Purge docker build cache"
+docker builder prune -f
+
+cd kernelci-api
+echo Retrieve API revision and branch
+api_rev=$(git show --pretty=format:%H -s origin/$KCI_API_BRANCH)
+api_url=$(git remote get-url origin)
+cd ..
+cd kernelci-core
+echo Retrieve Core revision and branch
+core_rev=$(git show --pretty=format:%H -s origin/$KCI_CORE_BRANCH)
+core_url=$(git remote get-url origin)
+build_args="--build-arg core_rev=$core_rev --build-arg api_rev=$api_rev --build-arg core_url=$core_url --build-arg api_url=$api_url"
+px_arg='--prefix=local/staging-'
+args="build --verbose $px_arg $build_args"
+echo Build docker images: kernelci args=$args
+./kci docker $args kernelci 
+failonerror
+echo Build docker images: k8s+kernelci
+./kci docker $args k8s kernelci
+failonerror
+echo Build docker images: api
+./kci docker $args api --version="$api_rev"
+failonerror
+echo Tag docker image of api to latest
+docker tag local/staging-api:$api_rev local/staging-api:latest
+failonerror
+echo Build docker images: clang-17+kselftest+kernelci for x86
+./kci docker $args clang-17 kselftest kernelci --arch x86
+failonerror
+echo Build docker images: gcc-10+kselftest+kernelci for x86
+./kci docker $args gcc-10 kselftest kernelci --arch x86
+failonerror
+echo Build docker images: gcc-10+kselftest+kernelci for arm64
+./kci docker $args gcc-10 kselftest kernelci --arch arm64
+failonerror
+
+

--- a/localinstall/2-install_api.sh
+++ b/localinstall/2-install_api.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+. ./main.cfg
+
+# i am groot?
+if [ $(id -u) -ne 0 ]; then
+    SUDO=sudo
+else
+    SUDO=
+fi
+
+cp .env-api kernelci/kernelci-api/.env
+cp api-configs.yaml kernelci/kernelci-core/config/core/
+cp kernelci-cli.toml kernelci/kernelci-core/kernelci.toml
+
+cd kernelci/kernelci-api
+mkdir -p docker/redis/data
+${SUDO} chmod -R 0777 docker/storage/data
+${SUDO} chmod -R 0777 docker/redis/data
+# enable ssh and storage nginx
+sed -i 's/^#  /  /' docker-compose.yaml
+if [ -f ../../ssh.key ]; then
+    echo "ssh.key already exists"
+else
+    # generate non-interactively ssh key to ssh.key
+    ssh-keygen -t rsa -b 4096 -N "" -f ../../ssh.key
+fi
+# get public key and add to docker/ssh/user-data/authorized_keys
+cat ../../ssh.key.pub > docker/ssh/user-data/authorized_keys
+
+# down, just in case old containers are running
+docker-compose down
+docker-compose up -d
+echo "Waiting for API to be up"
+sleep 1
+# loop until the API is up, try 5 times
+i=0
+while [ $i -lt 5 ]; do
+    ANSWER=$(curl http://localhost:8001/latest/)
+    # must be {"message":"KernelCI API"}
+    if [ "$ANSWER" != "{\"message\":\"KernelCI API\"}" ]; then
+        echo "API is not up"
+        i=$((i+1))
+        sleep 5
+    else
+        echo "API is up"
+        break
+    fi
+done
+
+# INFO, if you have issues with stale/old data, check for 
+# docker volume kernelci-api_mongodata and delete it
+../../helpers/scripts_setup_admin_user.exp "${YOUR_EMAIL}" "${ADMIN_PASSWORD}"
+
+cd ../kernelci-core
+echo "Issuing token for admin user"
+../../helpers/kci_user_token_admin.exp "${ADMIN_PASSWORD}" > ../../admin-token.txt
+ADMIN_TOKEN=$(cat ../../admin-token.txt)
+
+echo "[kci.secrets]
+api.\"docker-host\".token = \"$ADMIN_TOKEN\" 
+" >> kernelci.toml
+

--- a/localinstall/3-install_pipeline.sh
+++ b/localinstall/3-install_pipeline.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+. ./main.cfg
+
+## This is hacky way of inserting things that probably will outlive trivial patch after changes
+# find line number with storage:
+function append_storage() {
+line=$(grep -n "^storage:$" kernelci/kernelci-pipeline/config/pipeline.yaml | cut -d: -f1)
+head -n $line kernelci/kernelci-pipeline/config/pipeline.yaml > tmp.yaml
+# insert after line with storage: the following lines
+echo "
+  personal:
+    storage_type: backend
+    base_url: http://localhost:8080/user1/
+    api_url: http://localhost:8080/" >> tmp.yaml
+# insert the rest of the file
+tail -n +$((line+1)) kernelci/kernelci-pipeline/config/pipeline.yaml >> tmp.yaml
+mv tmp.yaml kernelci/kernelci-pipeline/config/pipeline.yaml
+}
+
+# replace in pipeline.yaml http://172.17.0.1:8001 to http://localhost:8001
+sed -i 's/http:\/\/172.17.0.1:8001/http:\/\/host.docker.internal:8001/g' kernelci/kernelci-pipeline/config/pipeline.yaml
+
+# TODO: Check if this is already done
+#append_storage
+
+# We can build on docker only
+sed -i 's/name: k8s-all/name: docker/g' kernelci/kernelci-pipeline/config/pipeline.yaml
+
+sed -i 's/env_file: .env/env_file: .env\/.env/g' kernelci/kernelci-pipeline/config/pipeline.yaml
+
+#-      - 'data/ssh/:/home/kernelci/data/ssh'
+#-      - 'data/output/:/home/kernelci/data/output'
+#+      - '/root/kernelci-pipeline/data/ssh/:/home/kernelci/data/ssh'
+#+      - '/root/kernelci-pipeline/data/output/:/home/kernelci/data/output'
+cd kernelci/kernelci-pipeline
+PIPELINE_PWD=$(pwd)
+# replace lab_type: kubernetes to lab_type: docker
+# This is BAD hack, but it works for now
+sed -i 's/lab_type: kubernetes/lab_type: docker/g' config/pipeline.yaml
+
+# replace data/output by $PIPELINE_PWD/data/output
+# might be two variants (default and staging)
+#      - '/data/kernelci-deploy-checkout/kernelci-pipeline/data/ssh/:/home/kernelci/data/ssh'
+#      - '/data/kernelci-deploy-checkout/kernelci-pipeline/data/output/:/home/kernelci/data/output'
+# AND
+#      - 'data/ssh/:/home/kernelci/data/ssh'
+#      - 'data/output/:/home/kernelci/data/output'
+sed -i "s|- 'data/output/|- '$PIPELINE_PWD/data/output/|g" config/pipeline.yaml
+sed -i "s|- 'data/ssh/|- '$PIPELINE_PWD/data/ssh/|g" config/pipeline.yaml
+# OR
+sed -i "s|- '/data/kernelci-deploy-checkout/kernelci-pipeline/data/ssh/|- '$PIPELINE_PWD/data/ssh/|g" config/pipeline.yaml
+sed -i "s|- '/data/kernelci-deploy-checkout/kernelci-pipeline/data/output/|- '$PIPELINE_PWD/data/output/|g" config/pipeline.yaml
+
+# set 777 to data/output and data/ssh (TODO: or set proper uid, kernelci is 1000?)
+chmod -R 777 data
+chmod 777 data/ssh
+cp ../../ssh.key data/ssh/id_rsa_tarball
+chown 1000:1000 data/ssh/id_rsa_tarball
+chmod 600 data/ssh/id_rsa_tarball
+cd ../..
+
+#replace kernelci/staging- by local/staging-
+#TODO: Make PR to pipeline with ENV var for image prefix
+sed -i 's/kernelci\/staging-/local\/staging-/g' kernelci/kernelci-pipeline/docker-compose.yaml
+
+# same for yaml files in config
+sed -i 's/kernelci\/staging-/local\/staging-/g' kernelci/kernelci-pipeline/config/pipeline.yaml
+
+# check if kernelci/kernelci-pipeline/config/kernelci.toml
+# has [trigger] and then force = 1
+# this will force builds on each restart
+grep -q "force = 1" kernelci/kernelci-pipeline/config/kernelci.toml
+if [ $? -ne 0 ]; then
+    sed -i '/\[trigger\]/a force = 1' kernelci/kernelci-pipeline/config/kernelci.toml
+fi
+
+# remove from pipeline yaml all build_configs:
+sed -i '/build_configs:/,$d' kernelci/kernelci-pipeline/config/pipeline.yaml
+# add 
+cat <<EOF >> kernelci/kernelci-pipeline/config/pipeline.yaml
+build_configs:
+  kernelci_staging-stable:
+    tree: kernelci
+    branch: 'staging-stable'
+    variants: *build-variants
+EOF
+
+#create .env
+#KCI_STORAGE_CREDENTIALS=L0CALT0KEN
+#KCI_API_TOKEN=
+#API_TOKEN=
+API_TOKEN=$(cat admin-token.txt)
+echo "KCI_STORAGE_CREDENTIALS=/home/kernelci/data/ssh/id_rsa_tarball" > .env
+echo "KCI_API_TOKEN=${API_TOKEN}" >> .env
+echo "API_TOKEN=${API_TOKEN}" >> .env
+cp .env kernelci/kernelci-pipeline/.docker-env
+mv .env kernelci/kernelci-pipeline/.env

--- a/localinstall/4-start-cycle.sh
+++ b/localinstall/4-start-cycle.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+. ./main.cfg
+
+cd kernelci/kernelci-pipeline
+docker-compose down
+docker-compose up -d
+echo "You can view now logs of containers using docker logs -f <container_id> or docker-compose logs -f in kernelci/kernelci-pipeline or kernelci/kernelci-api directories"
+echo "Also you can do docker ps to see running containers, and in case of ongoing builds, you can view their logs too by docker logs -f <container_id>"
+echo "You can also open API viewer at http://127.0.0.1:8001/viewer"

--- a/localinstall/README.md
+++ b/localinstall/README.md
@@ -1,0 +1,16 @@
+# kci-easy
+
+Get your own KernelCI instance up and running in no time.
+
+## Getting started
+
+### Prerequisites
+
+- git
+- Docker (with `compose` plugin, set up for a regular user)
+- Python environment with [KernelCI core dependencies](https://github.com/kernelci/kernelci-core/blob/main/requirements.txt) installed
+- expect
+
+### Running
+
+Change `ADMIN_PASSWORD` in the `main.cfg`, then run shell scripts from the root directory in their order.

--- a/localinstall/api-configs.yaml
+++ b/localinstall/api-configs.yaml
@@ -1,0 +1,10 @@
+api:
+
+  docker-host:
+    url: http://127.0.0.1:8001
+
+  early-access:
+    url: https://kernelci-api.eastus.cloudapp.azure.com
+
+  staging.kernelci.org:
+    url: https://staging.kernelci.org:9000

--- a/localinstall/helpers/kci_user_token_admin.exp
+++ b/localinstall/helpers/kci_user_token_admin.exp
@@ -1,0 +1,10 @@
+#!/usr/bin/expect -f
+
+set password [lindex $argv 0]
+log_user 0
+spawn ./kci user token admin
+expect "Password:"
+send -- "$password\r"
+expect "\r\n"
+log_user 1
+expect eof

--- a/localinstall/helpers/scripts_setup_admin_user.exp
+++ b/localinstall/helpers/scripts_setup_admin_user.exp
@@ -1,0 +1,9 @@
+#!/usr/bin/expect -f
+
+set password [lindex $argv 1]
+spawn ./scripts/setup_admin_user --email [lindex $argv 0]
+expect "Password for user 'admin':"
+send -- "$password\r"
+expect "Retype password for user 'admin':"
+send -- "$password\r"
+expect eof

--- a/localinstall/kernelci-cli.toml
+++ b/localinstall/kernelci-cli.toml
@@ -1,0 +1,9 @@
+[DEFAULT]
+api = "docker-host"
+indent = 4
+
+[kci]
+api = "docker-host"
+storage = "personal"
+config = ["config/core"]
+

--- a/localinstall/main.cfg
+++ b/localinstall/main.cfg
@@ -1,0 +1,11 @@
+#!/bin/sh
+KCI_CORE_REPO=https://github.com/kernelci/kernelci-core
+KCI_CORE_BRANCH=staging.kernelci.org
+KCI_API_REPO=https://github.com/kernelci/kernelci-api
+KCI_API_BRANCH=staging.kernelci.org
+KCI_PIPELINE_REPO=https://github.com/kernelci/kernelci-pipeline
+KCI_PIPELINE_BRANCH=staging.kernelci.org
+YOUR_EMAIL=denys.f@collabora.com
+ADMIN_PASSWORD="Ch4n93m3HpL33z"
+STORAGE_TOKEN="FKDFLKJFLKDJFLK"
+#KCI_CACHE=1


### PR DESCRIPTION
This utility has been originally created by:
Denys Fedoryshchenko <denys.f@collabora.com>

Its goal is to provide easy to set up and use environment for the new KernelCI system. It can serve as a local development instance of the system.