### PR TITLE
fix(kci-pending,kci-rootfs): Fix docker prefix and hard-fail on git errors

### DIFF
--- a/tools/kci-pending.py
+++ b/tools/kci-pending.py
@@ -120,10 +120,17 @@ def merge_prs(args, users):
 
     if args.push:
         logging.info('Pushing changes to remote')
-        os.system(f'cd {args.repo} && git push origin HEAD:{args.branch} --force')
+        r = os.system(f'cd {args.repo} && git push origin HEAD:{args.branch} --force')
+        # if git failed - hard fail here
+        if r:
+            logging.error('Failed to push changes to remote')
+            sys.exit(1)
+
+
         logging.info('Changes pushed to remote')
     else:
         logging.info('Changes not pushed to remote')
+
 
 def main():
     parser = argparse.ArgumentParser(description='KernelCI staging v2')

--- a/tools/kci-rootfs.py
+++ b/tools/kci-rootfs.py
@@ -16,7 +16,7 @@ import sys
 import signal
 import hashlib
 
-VERSION="0.2"
+VERSION="0.3"
 containerid=""
 
 
@@ -244,17 +244,13 @@ def main():
     parser.add_argument('--name', help='Name of the rootfs to build')
     parser.add_argument('--branch', help='Branch of kernelci-core to use', default="main")
     parser.add_argument('--all', help='Build all rootfs images', action='store_true')
-    parser.add_argument('--staging', help='Use staging- prefix for rootfs image docker builder', action='store_true')
+    # We might use dockerhub, but preferable to move to ghcr.io then we have different prefix now
+    parser.add_argument('--prefix', help='Prefix for rootfs image docker builder (dhcr.io/kernelci-staging or /kernelci or /kernelci-staging)', default="ghcr.io/kernelci")
     args = parser.parse_args()
 
     containerid = get_containerid()
     verify_docker()
     prepare_kci_source(args.branch)
-
-    if args.staging:
-        prefix = "staging-"
-    else:
-        prefix = ""
     
     # if branch set to staging, check if staging- prefix is used, if not - suggest to use --staging
     if args.branch == "staging.kernelci.org" and not args.staging:
@@ -266,7 +262,8 @@ def main():
         for rootfs in allfs:
             arch_list = allfs[rootfs]["arch_list"]
             rootfs_type = allfs[rootfs]["rootfs_type"]
-            docker_image = f"kernelci/{prefix}{rootfs_type}:kernelci"
+            #docker_image = f"kernelci/{prefix}{rootfs_type}:kernelci"
+            docker_image = f"{args.prefix}{rootfs_type}:kernelci"
             prepare_docker_container(docker_image, containerid)
             for arch in arch_list:
                 print(f"Building {rootfs} for {arch} type {rootfs_type}")


### PR DESCRIPTION


1)Fix docker prefix to new scheme (we prefer ghcr.io) 
2)Hard-fail if git failed