### PR TITLE
fix(kci-rootfs): Replace remaining misprefixed Docker image names

### DIFF
--- a/tools/kci-rootfs.py
+++ b/tools/kci-rootfs.py
@@ -284,7 +284,7 @@ def main():
         print("rootfs_type not found in config")
         exit(1)
 
-    docker_image = f"kernelci/{prefix}{rootfs_type}:kernelci"
+    docker_image = f"{args.prefix}{rootfs_type}:kernelci"
     prepare_docker_container(docker_image, containerid)
 
     # if args.arch have a comma, build for all archs in the list


### PR DESCRIPTION
Patch 5082d25c5d1d231cac3d25abefe8ad0706da42af changed prefix scheme for Docker images used as rootfs builders. This patch replaces remaining occurences of the old-style prefixed names.