### PR TITLE
fix(kci-rootfs): Change default rootfs builder Docker image prefix

### DIFF
--- a/tools/kci-rootfs.py
+++ b/tools/kci-rootfs.py
@@ -244,8 +244,7 @@ def main():
     parser.add_argument('--name', help='Name of the rootfs to build')
     parser.add_argument('--branch', help='Branch of kernelci-core to use', default="main")
     parser.add_argument('--all', help='Build all rootfs images', action='store_true')
-    # We might use dockerhub, but preferable to move to ghcr.io then we have different prefix now
-    parser.add_argument('--prefix', help='Prefix for rootfs image docker builder (dhcr.io/kernelci-staging or /kernelci or /kernelci-staging)', default="ghcr.io/kernelci")
+    parser.add_argument('--prefix', help='Prefix for rootfs builder Docker image (ghcr.io/kernelci/staging- or kernelci/staging- or kernelci/)', default="ghcr.io/kernelci/")
     args = parser.parse_args()
 
     containerid = get_containerid()
@@ -262,7 +261,6 @@ def main():
         for rootfs in allfs:
             arch_list = allfs[rootfs]["arch_list"]
             rootfs_type = allfs[rootfs]["rootfs_type"]
-            #docker_image = f"kernelci/{prefix}{rootfs_type}:kernelci"
             docker_image = f"{args.prefix}{rootfs_type}:kernelci"
             prepare_docker_container(docker_image, containerid)
             for arch in arch_list:


### PR DESCRIPTION
Patch 5082d25c5d1d231cac3d25abefe8ad0706da42af changed prefix scheme for Docker images used as rootfs builders.

Previously prefixes differentiated only staging and production images ("staging-" vs. empty prefix). Now they may also include container registry information (with fallback to Docker Hub if omitted).

This patch changes default value of the prefix to separate container registry information from Docker image name. By default:

- production images
- taken from ghcr.io registry

will be used.