### PR TITLE
(k8s) Add api.kernelci.org to issuer.yaml for tls generation

### DIFF
--- a/kubernetes/manifests/issuer.yaml
+++ b/kubernetes/manifests/issuer.yaml
@@ -27,6 +27,7 @@ spec:
         selector:
           dnsNames:
             - 'kernelci-api.westus3.cloudapp.azure.com'
+            - 'api.kernelci.org'
       - http01:
           ingress:
             ingressTemplate:
@@ -41,3 +42,4 @@ spec:
         selector:
           dnsNames:
             - 'kernelci-pipeline.westus3.cloudapp.azure.com'
+            - 'api.kernelci.org'


### PR DESCRIPTION
We have new domain, so we need to update issuer manifest