### PR TITLE
Improve workaround for docker getting stuck

### DIFF
--- a/staging.kernelci.org
+++ b/staging.kernelci.org
@@ -143,6 +143,14 @@ cmd_rotate_tree() {
     echo $tree
 }
 
+docker_workaround() {
+    echo "Restarting containerd and docker"
+    sudo systemctl restart containerd docker
+    echo "Waiting 5 seconds for services to restart"
+    sleep 5
+    ~/run-dozzle
+}
+
 cmd_api_pipeline() {
     compose_files="\
 -f docker-compose.yaml \
@@ -158,14 +166,11 @@ cmd_api_pipeline() {
     git checkout origin/staging.kernelci.org
     echo "Pulling pipeline containers"
     docker-compose $compose_files pull
-    docker-compose $compose_files down --remove-orphans
+    docker-compose $compose_files down --remove-orphans || true
     # verify if it failed due orphaned network bug
     if [ $? -ne 0 ]; then
         echo "Failed to stop pipeline containers, restarting containerd and docker"
-        sudo systemctl restart containerd docker
-        echo "Waiting 5 seconds for services to restart"
-        sleep 5
-        ~/run-dozzle
+        docker_workaround
         echo "Attempting to restart pipeline containers again"
         docker-compose $compose_files down --remove-orphans
     fi
@@ -179,7 +184,14 @@ cmd_api_pipeline() {
     git checkout origin/staging.kernelci.org
     docker-compose pull $api_services
     echo "Stopping API containers"
-    docker-compose down
+    docker-compose down || true
+    # verify if it failed due orphaned network bug
+    if [ $? -ne 0 ]; then
+        echo "Failed to stop API containers, restarting containerd and docker"
+        docker_workaround
+        echo "Attempting to restart API containers again"
+        docker-compose down
+    fi
     echo "Starting API containers"
     docker-compose up -d $api_services
     cd -


### PR DESCRIPTION
Workaround was incomplete, we are still hitting bug:
```
Removing kernelci-pipeline-timeout            ... done
Removing kernelci-pipeline-result-summary     ... done
Removing network kernelci-pipeline_default
ERROR: error while removing network: network kernelci-pipeline_default id e9b9771a22819f4b8189745026a08467dab3d008ae5f7a94abc9a464086c201a has active endpoints
```