### PR TITLE
Fix: remove non-existent reference in 'pipeline.yaml' for local deployment, build missing pipeline images

### DIFF
--- a/localinstall/1-rebuild_all.sh
+++ b/localinstall/1-rebuild_all.sh
@@ -74,11 +74,16 @@ echo Retrieve API revision and branch
 api_rev=$(git show --pretty=format:%H -s origin/$KCI_API_BRANCH)
 api_url=$(git remote get-url origin)
 cd ..
+cd kernelci-pipeline
+echo Retrieve Pipeline revision and branch
+pipeline_rev=$(git show --pretty=format:%H -s origin/$KCI_PIPELINE_BRANCH)
+pipeline_url=$(git remote get-url origin)
+cd ..
 cd kernelci-core
 echo Retrieve Core revision and branch
 core_rev=$(git show --pretty=format:%H -s origin/$KCI_CORE_BRANCH)
 core_url=$(git remote get-url origin)
-build_args="--build-arg core_rev=$core_rev --build-arg api_rev=$api_rev --build-arg core_url=$core_url --build-arg api_url=$api_url"
+build_args="--build-arg pipeline_rev=$pipeline_rev --build-arg core_rev=$core_rev --build-arg api_rev=$api_rev --build-arg pipeline_url=$pipeline_url --build-arg core_url=$core_url --build-arg api_url=$api_url"
 px_arg='--prefix=local/staging-'
 args="build --verbose $px_arg $build_args"
 echo Build docker images: kernelci args=$args
@@ -90,8 +95,14 @@ failonerror
 echo Build docker images: api
 ./kci docker $args kernelci api --version="$api_rev"
 failonerror
+echo Build docker images: pipeline
+./kci docker $args kernelci pipeline --version="$pipeline_rev"
+failonerror
 echo Tag docker image of api to latest
 docker tag local/staging-kernelci:api-$api_rev local/staging-kernelci:api
+failonerror
+echo Tag docker image of pipeline to latest
+docker tag local/staging-kernelci:pipeline-$pipeline_rev local/staging-kernelci:pipeline
 failonerror
 echo Build docker images: clang-17+kselftest+kernelci for x86
 ./kci docker $args clang-17 kselftest kernelci --arch x86

--- a/localinstall/3-install_pipeline.sh
+++ b/localinstall/3-install_pipeline.sh
@@ -82,7 +82,6 @@ build_configs:
   kernelci_staging-stable:
     tree: kernelci
     branch: 'staging-stable'
-    variants: *build-variants
 EOF
 
 #create .env


### PR DESCRIPTION
This PR fixes the following issue when starting a local deployment with a 'kernelci-pipeline-lava-callback' service with the default `pipeline.yaml`.

Steps to reproduce:
```
cd localinstall
python kci-deploy.py
cd kernelci/kernelci-pipeline
docker-compose -f docker-compose-lava.yaml up
```

Issue:
```
Traceback (most recent call last):
  File "/home/kernelci/pipeline/lava_callback.py", line 34, in <module>
    CONFIGS = kernelci.config.load(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/kernelci/config/__init__.py", line 191, in load
    data = load_yaml(config_paths)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/kernelci/config/__init__.py", line 149, in load_yaml
    data = load_single_yaml(path)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/kernelci/config/__init__.py", line 86, in load_single_yaml
    for _, data in iterate_yaml_files(config_path):
  File "/usr/local/lib/python3.11/site-packages/kernelci/config/__init__.py", line 30, in iterate_yaml_files
    data = yaml.safe_load(yaml_file)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/yaml/__init__.py", line 125, in safe_load
    return load(stream, SafeLoader)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/yaml/__init__.py", line 81, in load
    return loader.get_single_data()
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/yaml/constructor.py", line 49, in get_single_data
    node = self.get_single_node()
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/yaml/composer.py", line 36, in get_single_node
    document = self.compose_document()
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/yaml/composer.py", line 55, in compose_document
    node = self.compose_node(None, None)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/yaml/composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/yaml/composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/yaml/composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/yaml/composer.py", line 68, in compose_node
    raise ComposerError(None, None, "found undefined alias %r"
yaml.composer.ComposerError: found undefined alias 'build-variants'
  in "config/pipeline.yaml", line 189, column 15
```

and add the build of missing pipeline images (related to https://github.com/kernelci/kernelci-pipeline/pull/1102).