### PR TITLE
Fix kernelci.toml generation for local deployment

### DIFF
--- a/localinstall/2-install_api.sh
+++ b/localinstall/2-install_api.sh
@@ -68,7 +68,7 @@ fi
 cd ../kernelci-core
 echo "Issuing token for admin user"
 ../../helpers/kci_user_token_admin.exp "${ADMIN_PASSWORD}" > ../../admin-token.txt
-ADMIN_TOKEN=$(cat ../../admin-token.txt)
+ADMIN_TOKEN=$(cat ../../admin-token.txt | tr -d '\r\n')
 
 echo "[kci.secrets]
 api.\"docker-host\".token = \"$ADMIN_TOKEN\" 


### PR DESCRIPTION
This PR fixes the generation of the `kernelci.toml` for `kernelci-core` for local deployment:

```
Traceback (most recent call last):
  File "/var/home/tollsimy/lfx-mentorship/kernelCI/kernelci-deploy/localinstall/kernelci/kernelci-core/./kci", line 35, in <module>
    main()
  File "/var/home/tollsimy/lfx-mentorship/kernelCI/kernelci-deploy/localinstall/kernelci/kernelci-core/./kci", line 31, in main
    kci()  # pylint: disable=no-value-for-parameter
    ^^^^^
  File "/var/home/tollsimy/lfx-mentorship/kernelCI/kernelci-deploy/localinstall/env/lib64/python3.12/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/tollsimy/lfx-mentorship/kernelCI/kernelci-deploy/localinstall/env/lib64/python3.12/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/var/home/tollsimy/lfx-mentorship/kernelCI/kernelci-deploy/localinstall/env/lib64/python3.12/site-packages/click/core.py", line 1654, in invoke
    super().invoke(ctx)
  File "/var/home/tollsimy/lfx-mentorship/kernelCI/kernelci-deploy/localinstall/env/lib64/python3.12/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/tollsimy/lfx-mentorship/kernelCI/kernelci-deploy/localinstall/env/lib64/python3.12/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/tollsimy/lfx-mentorship/kernelCI/kernelci-deploy/localinstall/env/lib64/python3.12/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/tollsimy/lfx-mentorship/kernelCI/kernelci-deploy/localinstall/kernelci/kernelci-core/kernelci/cli/__init__.py", line 184, in kci
    ctx.obj = CommandSettings(settings)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/tollsimy/lfx-mentorship/kernelCI/kernelci-deploy/localinstall/kernelci/kernelci-core/kernelci/cli/__init__.py", line 101, in __init__
    self._settings = kernelci.settings.Settings(settings_path)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/tollsimy/lfx-mentorship/kernelCI/kernelci-deploy/localinstall/kernelci/kernelci-core/kernelci/settings.py", line 48, in __init__
    self._settings = toml.load(path) if path else {}
                     ^^^^^^^^^^^^^^^
  File "/var/home/tollsimy/lfx-mentorship/kernelCI/kernelci-deploy/localinstall/env/lib64/python3.12/site-packages/toml/decoder.py", line 134, in load
    return loads(ffile.read(), _dict, decoder)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/home/tollsimy/lfx-mentorship/kernelCI/kernelci-deploy/localinstall/env/lib64/python3.12/site-packages/toml/decoder.py", line 340, in loads
    raise TomlDecodeError("Unbalanced quotes", original, i)
toml.decoder.TomlDecodeError: Unbalanced quotes (line 11 column 216 char 344)
```

since the generated `kernelci.toml` is actually generated as follows:
```
[DEFAULT]
api = "docker-host"
indent = 4

[kci]
api = "docker-host"
storage = "personal"
config = ["config/core"]

[kci.secrets]
api."docker-host".token = "token
" 
```